### PR TITLE
Make cloud API/web/MQTT hosts configurable via build flag and env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT OBN_VERSION)
 endif()
 
 set(OBN_CLOUD_API_URL      "" CACHE STRING "Override cloud REST API base URL (e.g. https://api.example.com).")
-set(OBN_CLOUD_WEB_URL      "" CACHE STRING "Override cloud web portal base URL (e.g. https://example.com).")
+set(OBN_CLOUD_WEB_URL      "" CACHE STRING "Override cloud web portal base URL, trailing slash required (e.g. https://example.com/).")
 set(OBN_CLOUD_MQTT_HOSTNAME "" CACHE STRING "Override cloud MQTT broker hostname (no scheme, no port).")
 if(OBN_CLOUD_API_URL OR OBN_CLOUD_WEB_URL OR OBN_CLOUD_MQTT_HOSTNAME)
     message(STATUS "obn: cloud endpoint overrides")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,21 @@ if(NOT OBN_VERSION)
     )
 endif()
 
+set(OBN_CLOUD_API_URL      "" CACHE STRING "Override cloud REST API base URL (e.g. https://api.example.com).")
+set(OBN_CLOUD_WEB_URL      "" CACHE STRING "Override cloud web portal base URL (e.g. https://example.com).")
+set(OBN_CLOUD_MQTT_HOSTNAME "" CACHE STRING "Override cloud MQTT broker hostname (no scheme, no port).")
+if(OBN_CLOUD_API_URL OR OBN_CLOUD_WEB_URL OR OBN_CLOUD_MQTT_HOSTNAME)
+    message(STATUS "obn: cloud endpoint overrides")
+    if(OBN_CLOUD_API_URL)
+        message(STATUS "  api  = ${OBN_CLOUD_API_URL}")
+    endif()
+    if(OBN_CLOUD_WEB_URL)
+        message(STATUS "  web  = ${OBN_CLOUD_WEB_URL}")
+    endif()
+    if(OBN_CLOUD_MQTT_HOSTNAME)
+        message(STATUS "  mqtt = ${OBN_CLOUD_MQTT_HOSTNAME}")
+    endif()
+endif()
 # First three dotted components of OBN_VERSION (MM.mm.pp from MM.mm.pp.rr)
 # as a single preprocessor integer 0xMMmmpp for #if ABI_VERSION in
 # include/obn/bambu_networking.hpp (matches Studio's 8-char prefix gate).
@@ -305,6 +320,9 @@ target_compile_definitions(bambu_networking PRIVATE
     OBN_VERSION_STRING="${OBN_VERSION}"
     ABI_VERSION=${OBN_ABI_VERSION_HEX}
     OBN_ENABLE_WORKAROUNDS=$<BOOL:${OBN_ENABLE_WORKAROUNDS}>
+    OBN_CLOUD_API_URL_DEFAULT="${OBN_CLOUD_API_URL}"
+    OBN_CLOUD_WEB_URL_DEFAULT="${OBN_CLOUD_WEB_URL}"
+    OBN_CLOUD_MQTT_HOSTNAME_DEFAULT="${OBN_CLOUD_MQTT_HOSTNAME}"
     ${_obn_git_compile_defs}
 )
 target_link_libraries(bambu_networking PRIVATE

--- a/configure
+++ b/configure
@@ -92,9 +92,9 @@ Cloud endpoint overrides:
                              e.g. https://api.example.com. Replaces
                              https://api.bambulab.com / .bambulab.cn.
                              Runtime env: OBN_CLOUD_API_URL.
-  --cloud-web-url=URL        Cloud web portal base URL (no trailing slash),
-                             e.g. https://example.com. Replaces
-                             https://bambulab.com / .bambulab.cn.
+  --cloud-web-url=URL        Cloud web portal base URL (trailing slash
+                             required), e.g. https://example.com/.
+                             Replaces https://bambulab.com / .bambulab.cn.
                              Runtime env: OBN_CLOUD_WEB_URL.
   --cloud-mqtt-hostname=HOST Cloud MQTT broker hostname (no scheme, no port),
                              e.g. mqtt.example.com. Replaces

--- a/configure
+++ b/configure
@@ -339,9 +339,9 @@ fi
 set -- -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
 [ -n "$PREFIX" ]              && set -- "$@" -DCMAKE_INSTALL_PREFIX="$PREFIX"
 [ -n "$OBN_VERSION" ]         && set -- "$@" -DOBN_VERSION="$OBN_VERSION"
-[ -n "$CLOUD_API_URL" ]       && set -- "$@" -DOBN_CLOUD_API_URL="$CLOUD_API_URL"
-[ -n "$CLOUD_WEB_URL" ]       && set -- "$@" -DOBN_CLOUD_WEB_URL="$CLOUD_WEB_URL"
-[ -n "$CLOUD_MQTT_HOSTNAME" ] && set -- "$@" -DOBN_CLOUD_MQTT_HOSTNAME="$CLOUD_MQTT_HOSTNAME"
+set -- "$@" -DOBN_CLOUD_API_URL="$CLOUD_API_URL"
+set -- "$@" -DOBN_CLOUD_WEB_URL="$CLOUD_WEB_URL"
+set -- "$@" -DOBN_CLOUD_MQTT_HOSTNAME="$CLOUD_MQTT_HOSTNAME"
 set -- "$@" \
     -DOBN_CLIENT_TYPE="$CLIENT_TYPE" \
     -DOBN_ENABLE_WORKAROUNDS="$WORKAROUNDS" \

--- a/configure
+++ b/configure
@@ -14,6 +14,9 @@ CLIENT_TYPE=bambu_studio
 WORKAROUNDS=ON
 TESTS=OFF
 PATCH_CONF=ON
+CLOUD_API_URL=""
+CLOUD_WEB_URL=""
+CLOUD_MQTT_HOSTNAME=""
 EXTRA_CMAKE_ARGS=""
 
 usage() {
@@ -81,6 +84,23 @@ Optional features:
                              OrcaSlicer.conf). Use this for staging or
                              if you manage the conf yourself.
 
+Cloud endpoint overrides:
+  Each value below replaces the built-in Bambu default at build time. The
+  matching runtime environment variable always wins over the compiled-in
+  value.
+  --cloud-api-url=URL        Cloud REST API base URL (no trailing slash),
+                             e.g. https://api.example.com. Replaces
+                             https://api.bambulab.com / .bambulab.cn.
+                             Runtime env: OBN_CLOUD_API_URL.
+  --cloud-web-url=URL        Cloud web portal base URL (no trailing slash),
+                             e.g. https://example.com. Replaces
+                             https://bambulab.com / .bambulab.cn.
+                             Runtime env: OBN_CLOUD_WEB_URL.
+  --cloud-mqtt-hostname=HOST Cloud MQTT broker hostname (no scheme, no port),
+                             e.g. mqtt.example.com. Replaces
+                             us.mqtt.bambulab.com / cn.mqtt.bambulab.com.
+                             Runtime env: OBN_CLOUD_MQTT_HOSTNAME.
+
 Other:
   --cmake-arg=ARG        Extra flag passed verbatim to cmake; repeat for
                          multiple flags (e.g. --cmake-arg=-GNinja).
@@ -107,6 +127,9 @@ for arg in "$@"; do
         --enable-tests)            TESTS=ON ;;
         --no-conf-patch)           PATCH_CONF=OFF ;;
         --with-conf-patch)         PATCH_CONF=ON ;;
+        --cloud-api-url=*)         CLOUD_API_URL="${arg#*=}" ;;
+        --cloud-web-url=*)         CLOUD_WEB_URL="${arg#*=}" ;;
+        --cloud-mqtt-hostname=*)   CLOUD_MQTT_HOSTNAME="${arg#*=}" ;;
         --video-backend=*)
             printf 'configure: --video-backend is deprecated and ignored '\
 '(libBambuSource now passes raw H.264 straight to gstbambusrc, '\
@@ -314,8 +337,11 @@ EOF
 fi
 
 set -- -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
-[ -n "$PREFIX" ]      && set -- "$@" -DCMAKE_INSTALL_PREFIX="$PREFIX"
-[ -n "$OBN_VERSION" ] && set -- "$@" -DOBN_VERSION="$OBN_VERSION"
+[ -n "$PREFIX" ]              && set -- "$@" -DCMAKE_INSTALL_PREFIX="$PREFIX"
+[ -n "$OBN_VERSION" ]         && set -- "$@" -DOBN_VERSION="$OBN_VERSION"
+[ -n "$CLOUD_API_URL" ]       && set -- "$@" -DOBN_CLOUD_API_URL="$CLOUD_API_URL"
+[ -n "$CLOUD_WEB_URL" ]       && set -- "$@" -DOBN_CLOUD_WEB_URL="$CLOUD_WEB_URL"
+[ -n "$CLOUD_MQTT_HOSTNAME" ] && set -- "$@" -DOBN_CLOUD_MQTT_HOSTNAME="$CLOUD_MQTT_HOSTNAME"
 set -- "$@" \
     -DOBN_CLIENT_TYPE="$CLIENT_TYPE" \
     -DOBN_ENABLE_WORKAROUNDS="$WORKAROUNDS" \

--- a/configure.ps1
+++ b/configure.ps1
@@ -55,6 +55,12 @@ param(
     # a Visual Studio version (e.g. "Visual Studio 16 2019").
     [string]   $Generator    = "",
     [string]   $Architecture = "x64",
+    # Cloud endpoint overrides baked in at build time. Empty = keep Bambu
+    # defaults. The matching OBN_CLOUD_* environment variable wins at
+    # runtime, so the same DLL can be redirected without rebuilding.
+    [string]   $CloudApiUrl      = "",
+    [string]   $CloudWebUrl      = "",
+    [string]   $CloudMqttHostname = "",
     [string[]] $CMakeArg     = @()
 )
 
@@ -301,6 +307,9 @@ $cmakeArgs += @(
     "-DOBN_PATCH_CLIENT_CONF=$patchConfVal",
     "-DOBN_REGISTER_DSHOW_FILTER=$registerDshowVal"
 )
+if (-not [string]::IsNullOrWhiteSpace($CloudApiUrl))      { $cmakeArgs += "-DOBN_CLOUD_API_URL=$CloudApiUrl" }
+if (-not [string]::IsNullOrWhiteSpace($CloudWebUrl))      { $cmakeArgs += "-DOBN_CLOUD_WEB_URL=$CloudWebUrl" }
+if (-not [string]::IsNullOrWhiteSpace($CloudMqttHostname)) { $cmakeArgs += "-DOBN_CLOUD_MQTT_HOSTNAME=$CloudMqttHostname" }
 if ($CMakeArg.Count -gt 0) { $cmakeArgs += $CMakeArg }
 
 Write-Note ("cmake " + ($cmakeArgs -join " "))

--- a/configure.ps1
+++ b/configure.ps1
@@ -58,6 +58,11 @@ param(
     # Cloud endpoint overrides baked in at build time. Empty = keep Bambu
     # defaults. The matching OBN_CLOUD_* environment variable wins at
     # runtime, so the same DLL can be redirected without rebuilding.
+    #   -CloudApiUrl       : REST API base, no trailing slash
+    #                        (e.g. https://api.example.com).
+    #   -CloudWebUrl       : web portal base, WITH trailing slash
+    #                        (e.g. https://example.com/).
+    #   -CloudMqttHostname : MQTT broker hostname, no scheme, no port.
     [string]   $CloudApiUrl      = "",
     [string]   $CloudWebUrl      = "",
     [string]   $CloudMqttHostname = "",

--- a/configure.ps1
+++ b/configure.ps1
@@ -307,9 +307,9 @@ $cmakeArgs += @(
     "-DOBN_PATCH_CLIENT_CONF=$patchConfVal",
     "-DOBN_REGISTER_DSHOW_FILTER=$registerDshowVal"
 )
-if (-not [string]::IsNullOrWhiteSpace($CloudApiUrl))      { $cmakeArgs += "-DOBN_CLOUD_API_URL=$CloudApiUrl" }
-if (-not [string]::IsNullOrWhiteSpace($CloudWebUrl))      { $cmakeArgs += "-DOBN_CLOUD_WEB_URL=$CloudWebUrl" }
-if (-not [string]::IsNullOrWhiteSpace($CloudMqttHostname)) { $cmakeArgs += "-DOBN_CLOUD_MQTT_HOSTNAME=$CloudMqttHostname" }
+$cmakeArgs += "-DOBN_CLOUD_API_URL=$CloudApiUrl"
+$cmakeArgs += "-DOBN_CLOUD_WEB_URL=$CloudWebUrl"
+$cmakeArgs += "-DOBN_CLOUD_MQTT_HOSTNAME=$CloudMqttHostname"
 if ($CMakeArg.Count -gt 0) { $cmakeArgs += $CMakeArg }
 
 Write-Note ("cmake " + ($cmakeArgs -join " "))

--- a/include/obn/config.hpp
+++ b/include/obn/config.hpp
@@ -4,6 +4,16 @@
 #include <optional>
 #include <string>
 
+#ifndef OBN_CLOUD_API_URL_DEFAULT
+#define OBN_CLOUD_API_URL_DEFAULT ""
+#endif
+#ifndef OBN_CLOUD_WEB_URL_DEFAULT
+#define OBN_CLOUD_WEB_URL_DEFAULT ""
+#endif
+#ifndef OBN_CLOUD_MQTT_HOSTNAME_DEFAULT
+#define OBN_CLOUD_MQTT_HOSTNAME_DEFAULT ""
+#endif
+
 namespace obn::config {
 
 // Resolve config in this order of precedence: env var -> compiled default (CMake -D...)

--- a/include/obn/config.hpp
+++ b/include/obn/config.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+namespace obn::config {
+
+// Resolve config in this order of precedence: env var -> compiled default (CMake -D...)
+inline std::optional<std::string> resolve_override(const char* env_var,
+                                                   const char* compiled_default)
+{
+    if (const char* v = std::getenv(env_var); v && *v) return std::string(v);
+    if (compiled_default && *compiled_default) return std::string(compiled_default);
+    return std::nullopt;
+}
+
+} // namespace obn::config

--- a/src/cloud_auth.cpp
+++ b/src/cloud_auth.cpp
@@ -54,10 +54,10 @@ std::string api_host(const std::string& region)
 std::string web_host(const std::string& region)
 {
     if (auto o = config::resolve_override("OBN_CLOUD_WEB_URL", OBN_CLOUD_WEB_URL_DEFAULT)) return *o;
-    // No trailing slash: Studio appends "/sign-in" (WebUserLoginDialog)
-    // and "api/sign-in/ticket?..." (bind flow) to this value.
-    if (region == "CN" || region == "cn") return "https://bambulab.cn";
-    return "https://bambulab.com";
+    // Trailing slash required: Studio appends some suffixes with a
+    // leading slash ("/sign-in") and others without ("api/sign-in/..."),
+    if (region == "CN" || region == "cn") return "https://bambulab.cn/";
+    return "https://bambulab.com/";
 }
 
 AuthResult login_with_ticket(const std::string& region,

--- a/src/cloud_auth.cpp
+++ b/src/cloud_auth.cpp
@@ -1,5 +1,6 @@
 #include "obn/cloud_auth.hpp"
 
+#include "obn/config.hpp"
 #include "obn/http_client.hpp"
 #include "obn/json_lite.hpp"
 #include "obn/log.hpp"
@@ -45,12 +46,14 @@ std::string api_error(const obn::json::Value& root, long status)
 
 std::string api_host(const std::string& region)
 {
+    if (auto o = config::resolve_override("OBN_CLOUD_API_URL", OBN_CLOUD_API_URL_DEFAULT)) return *o;
     if (region == "CN" || region == "cn") return "https://api.bambulab.cn";
     return "https://api.bambulab.com";
 }
 
 std::string web_host(const std::string& region)
 {
+    if (auto o = config::resolve_override("OBN_CLOUD_WEB_URL", OBN_CLOUD_WEB_URL_DEFAULT)) return *o;
     // No trailing slash: Studio appends "/sign-in" (WebUserLoginDialog)
     // and "api/sign-in/ticket?..." (bind flow) to this value.
     if (region == "CN" || region == "cn") return "https://bambulab.cn";

--- a/src/cloud_session.cpp
+++ b/src/cloud_session.cpp
@@ -1,6 +1,7 @@
 #include "obn/cloud_session.hpp"
 
 #include "obn/bambu_networking.hpp"
+#include "obn/config.hpp"
 #include "obn/log.hpp"
 #include "obn/mqtt_client.hpp"
 
@@ -64,6 +65,7 @@ void CloudSession::configure(std::string region,
 
 std::string CloudSession::mqtt_host_() const
 {
+    if (auto o = config::resolve_override("OBN_CLOUD_MQTT_HOSTNAME", OBN_CLOUD_MQTT_HOSTNAME_DEFAULT)) return *o;
     if (region_ == "CN" || region_ == "cn") return "cn.mqtt.bambulab.com";
     return "us.mqtt.bambulab.com";
 }


### PR DESCRIPTION
Follow-up to https://github.com/ClusterM/open-bamboo-networking/issues/30

Add configuration options to use different hostnames for web/api/mqtt in cloud features.

Small inline helper added in (new) config.hpp, is that ok ? I you want me to reshape this in any different way that'll be no issue. Thx !