### PR TITLE
Windows on ARM support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 # Build and test open-bamboo-networking on Linux x64 / aarch64,
-# Windows x64 (MSVC + vcpkg manifest), and macOS arm64.
+# Windows x64 + ARM64 (MSVC + vcpkg manifest), and macOS arm64.
 # release.yml always builds both macOS architectures.
 #
 # Version strategy: the plugin must report a string whose first 8 characters
@@ -15,7 +15,7 @@
 #   * liblive555.so
 #   * network_plugins.json
 #
-# Windows artifacts (one set per ABI version):
+# Windows artifacts (one set per ABI version / architecture — x64 and ARM64):
 #   * bambu_networking.dll
 #   * BambuSource.dll
 #   * live555.dll (stub)
@@ -128,13 +128,16 @@ jobs:
           if-no-files-found: error
 
   build-windows:
-    name: v${{ matrix.abi }}.xx-windows-x64
+    name: v${{ matrix.abi }}.xx-windows-${{ matrix.arch }}
     needs: [discover-abi]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-2022' }}
     strategy:
       fail-fast: false
       matrix:
         abi: ${{ fromJSON(needs.discover-abi.outputs.abi-matrix) }}
+        arch:
+          - x64
+          - arm64
 
     steps:
       - name: Checkout
@@ -146,10 +149,15 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $staging = Join-Path $env:GITHUB_WORKSPACE "install"
           New-Item -ItemType Directory -Force -Path $staging | Out-Null
+          $arch = '${{ matrix.arch }}'
+          $cmakeArch = if ($arch -eq 'arm64') { 'ARM64' } else { 'x64' }
+          $triplet = if ($arch -eq 'arm64') { 'arm64-windows-static-md' } else { 'x64-windows-static-md' }
           .\configure.ps1 `
             -ClientType bambu_studio `
             -WithVersion '${{ matrix.abi }}.99' `
             -Prefix $staging `
+            -Architecture $cmakeArch `
+            -VcpkgTriplet $triplet `
             -PatchConf:$false `
             -RegisterDShowFilter:$false `
             -EnableTests:$true
@@ -191,7 +199,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: obn-v${{ matrix.abi }}.xx-windows-x64
+          name: obn-v${{ matrix.abi }}.xx-windows-${{ matrix.arch }}
           path: dist/
           if-no-files-found: error
 
@@ -395,6 +403,7 @@ jobs:
             case "$name" in
               *linux-x64*)       platform="Linux x64" ;;
               *linux-aarch64*)   platform="Linux aarch64" ;;
+              *windows-arm64*)   platform="Windows ARM64" ;;
               *windows-x64*)     platform="Windows x64" ;;
               *macos-arm64*)     platform="macOS (Apple Silicon)" ;;
               *macos-x64*|*macos-intel*) platform="macOS (Intel)" ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,13 +124,16 @@ jobs:
           if-no-files-found: error
 
   build-windows:
-    name: v${{ matrix.abi }}.xx-windows-x64
+    name: v${{ matrix.abi }}.xx-windows-${{ matrix.arch }}
     needs: [preflight]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-2022' }}
     strategy:
       fail-fast: false
       matrix:
         abi: ${{ fromJSON(needs.preflight.outputs.abi-matrix) }}
+        arch:
+          - x64
+          - arm64
 
     steps:
       - name: Checkout
@@ -142,10 +145,15 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $staging = Join-Path $env:GITHUB_WORKSPACE "install"
           New-Item -ItemType Directory -Force -Path $staging | Out-Null
+          $arch = '${{ matrix.arch }}'
+          $cmakeArch = if ($arch -eq 'arm64') { 'ARM64' } else { 'x64' }
+          $triplet = if ($arch -eq 'arm64') { 'arm64-windows-static-md' } else { 'x64-windows-static-md' }
           .\configure.ps1 `
             -ClientType bambu_studio `
             -WithVersion '${{ matrix.abi }}.99' `
             -Prefix $staging `
+            -Architecture $cmakeArch `
+            -VcpkgTriplet $triplet `
             -PatchConf:$false `
             -RegisterDShowFilter:$false `
             -EnableTests:$true
@@ -189,7 +197,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: obn-v${{ matrix.abi }}.xx-windows-x64
+          name: obn-v${{ matrix.abi }}.xx-windows-${{ matrix.arch }}
           path: dist/
           if-no-files-found: error
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Please note:
 - Linux x86_64 (primary target).
 - Linux aarch64 (primary target).
 - Windows x64 (experimental).
+- Windows ARM64 (experimental).
 - macOS (very experimental, works partially, not documented yet).
 
 ## Supported Bambu Studio versions (ABI versions)

--- a/configure.ps1
+++ b/configure.ps1
@@ -11,6 +11,7 @@
 #   .\configure.ps1 -ClientType orca_slicer
 #   .\configure.ps1 -BuildType Debug -EnableTests:$false
 #   .\configure.ps1 -VcpkgRoot C:\vcpkg -VcpkgTriplet x64-windows
+#   .\configure.ps1 -Architecture ARM64 -VcpkgTriplet arm64-windows-static-md
 #   .\configure.ps1 -Generator "Visual Studio 17 2022"   # pin a VS version
 #
 # If -Generator is omitted, it is not passed to CMake and CMake picks its
@@ -21,7 +22,8 @@
 # Requirements:
 #   - Visual Studio 2019 (toolset v142) -- matches the MSVC ABI Bambu Studio
 #     itself ships with. Newer toolsets *may* work but the std::string layout
-#     across the DLL boundary is not guaranteed.
+#     across the DLL boundary is not guaranteed. For Windows ARM64 use a VS
+#     install that includes the ARM64 C++ toolset (CI uses windows-11-arm).
 #   - vcpkg (manifest mode picks up vcpkg.json automatically).
 #   - cmake on PATH (3.16+).
 
@@ -47,12 +49,15 @@ param(
     # LIBCMT-vs-MSVCRT mismatch warning (LNK4098) and -- worse -- run two
     # copies of the C runtime side by side with diverging stdio and heap
     # state. -static (without -md) is left as an option for users who want
-    # the older default.
-    [ValidateSet("x64-windows","x64-windows-static","x64-windows-static-md","x86-windows","x86-windows-static")]
+    # the older default. Use arm64-windows-static-md for native Windows ARM64.
+    [ValidateSet("x64-windows","x64-windows-static","x64-windows-static-md","x86-windows","x86-windows-static","arm64-windows","arm64-windows-static-md")]
     [string]   $VcpkgTriplet = "x64-windows-static-md",
     # Empty = let CMake choose (-G omitted). Pass an explicit name to pin
     # a Visual Studio version (e.g. "Visual Studio 16 2019").
     [string]   $Generator    = "",
+    # CMake -A platform: "x64", "Win32", or "ARM64". When an arm64-* / x86-*
+    # triplet is selected and this is still the default "x64", configure.ps1
+    # rewrites it automatically below.
     [string]   $Architecture = "x64",
     [string[]] $CMakeArg     = @()
 )
@@ -264,12 +269,18 @@ if ([string]::IsNullOrEmpty($WithVersion)) {
 
 # ----- assemble cmake command line --------------------------------------
 
-# x86 builds usually want "Win32" as the architecture, x64 builds use "x64".
-# If the user picked an x86 triplet without flipping -Architecture, normalize
-# automatically so the generator string lines up with the deps vcpkg builds.
+# Keep -A in sync with the vcpkg triplet when the user only flipped the
+# triplet (or left -Architecture at its default "x64"):
+#   x86-*   → Win32
+#   arm64-* → ARM64
+#   x64-*   → x64 (default)
 if ($VcpkgTriplet -like "x86-*" -and $Architecture -eq "x64") {
     Write-Note "x86 triplet selected; switching architecture to Win32"
     $Architecture = "Win32"
+}
+if ($VcpkgTriplet -like "arm64-*" -and $Architecture -eq "x64") {
+    Write-Note "arm64 triplet selected; switching architecture to ARM64"
+    $Architecture = "ARM64"
 }
 
 # Convert booleans to ON/OFF first; if we inline the ternary into the

--- a/scripts/package-dist.sh
+++ b/scripts/package-dist.sh
@@ -12,6 +12,7 @@
 # Output: dist-out/obn-linux-x64.tar.gz
 #         dist-out/obn-linux-aarch64.tar.gz
 #         dist-out/obn-windows-x64.zip
+#         dist-out/obn-windows-arm64.zip
 #         dist-out/obn-macos-arm64.tar.gz
 #         dist-out/obn-macos-x64.tar.gz
 set -eu
@@ -129,6 +130,21 @@ generate_readme "Windows x64" "install.bat" \
     "Double-click install.bat, or run in PowerShell:  .\\\\install.ps1" "$STAGE/README.txt"
 (cd "$OUTDIR" && zip -qr obn-windows-x64.zip obn-windows-x64/)
 echo "  -> obn-windows-x64.zip"
+
+# ── Windows ARM64 ────────────────────────────────────────────────────────
+
+echo "Assembling obn-windows-arm64..."
+STAGE="$OUTDIR/obn-windows-arm64"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+collect_abi_dirs "obn-v*-windows-arm64" "$STAGE"
+cp "$REPO_ROOT/packaging/install.ps1" "$STAGE/"
+cp "$REPO_ROOT/packaging/install.bat" "$STAGE/"
+write_version_file "$STAGE"
+generate_readme "Windows ARM64" "install.bat" \
+    "Double-click install.bat, or run in PowerShell:  .\\\\install.ps1" "$STAGE/README.txt"
+(cd "$OUTDIR" && zip -qr obn-windows-arm64.zip obn-windows-arm64/)
+echo "  -> obn-windows-arm64.zip"
 
 # ── macOS arm64 ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to build scripts, CI matrices, and packaging; no runtime plugin or security logic is modified. Main risk is CI reliability on windows-11-arm runners and correct vcpkg ARM64 triplets.
> 
> **Overview**
> Adds **experimental Windows on ARM** support end-to-end: local configure, CI/release pipelines, packaged downloads, and docs.
> 
> **`configure.ps1`** now accepts `arm64-windows*` vcpkg triplets, documents ARM64 usage, and auto-sets CMake `-A ARM64` when an `arm64-*` triplet is chosen (same pattern as existing x86 → Win32).
> 
> **Build and release workflows** extend the Windows job with an **`arch` matrix (`x64`, `arm64`)**, use **`windows-11-arm`** for ARM64, pass **`-Architecture` / `-VcpkgTriplet`** per arch, and name artifacts **`obn-v*.xx-windows-${{ matrix.arch }}`**.
> 
> **`scripts/package-dist.sh`** assembles a new **`obn-windows-arm64.zip`** from those artifacts; the **GitHub Pages** download table recognizes **Windows ARM64** filenames.
> 
> **README** lists Windows ARM64 under supported platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2c26305bf1678e0a46a0f77a9cb3fda81365ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->