### PR TITLE
macOS: static libcurl and openssl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,16 +219,15 @@ jobs:
       - name: Install build dependencies
         run: |
           set -eu
-          for pkg in pkg-config cmake openssl@3 curl cjson zlib uthash; do
+          # curl/cjson/zlib are NOT brew runtime deps: libcurl is vendored
+          # static, cJSON is vendored with mosquitto, zlib is system.
+          # openssl@3 is build-time only (static .a archives embedded).
+          for pkg in pkg-config cmake openssl@3 uthash; do
             brew list "$pkg" &>/dev/null || brew install "$pkg"
           done
           {
             echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
-            PC="$(brew --prefix openssl@3)/lib/pkgconfig"
-            PC="${PC}:$(brew --prefix curl)/lib/pkgconfig"
-            PC="${PC}:$(brew --prefix zlib)/lib/pkgconfig"
-            PC="${PC}:$(brew --prefix cjson)/lib/pkgconfig"
-            echo "PKG_CONFIG_PATH=${PC}"
+            echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig"
           } >> "$GITHUB_ENV"
 
       - name: Configure
@@ -247,6 +246,22 @@ jobs:
 
       - name: Verify built plugin exports every ABI symbol
         run: tools/check_abi_compat.sh --abi='${{ matrix.abi }}' --so=build/libbambu_networking.dylib
+
+      - name: Assert no Homebrew runtime dylib deps
+        run: |
+          set -eu
+          # Static OpenSSL + vendored curl must leave no /opt/homebrew or
+          # /usr/local/opt NEEDED entries (issue #60).
+          bad=0
+          for dylib in build/libbambu_networking.dylib build/libBambuSource.dylib; do
+            echo "== otool -L $dylib =="
+            otool -L "$dylib"
+            if otool -L "$dylib" | grep -E '/opt/homebrew/|/usr/local/opt/'; then
+              echo "error: $dylib still links Homebrew paths" >&2
+              bad=1
+            fi
+          done
+          exit "$bad"
 
       - name: Stage artifacts
         run: |
@@ -282,16 +297,12 @@ jobs:
   #     - name: Install build dependencies
   #       run: |
   #         set -eu
-  #         for pkg in pkg-config cmake openssl@3 curl cjson zlib uthash; do
+  #         for pkg in pkg-config cmake openssl@3 uthash; do
   #           brew list "$pkg" &>/dev/null || brew install "$pkg"
   #         done
   #         {
   #           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
-  #           PC="$(brew --prefix openssl@3)/lib/pkgconfig"
-  #           PC="${PC}:$(brew --prefix curl)/lib/pkgconfig"
-  #           PC="${PC}:$(brew --prefix zlib)/lib/pkgconfig"
-  #           PC="${PC}:$(brew --prefix cjson)/lib/pkgconfig"
-  #           echo "PKG_CONFIG_PATH=${PC}"
+  #           echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig"
   #         } >> "$GITHUB_ENV"
   #
   #     - name: Configure
@@ -310,6 +321,20 @@ jobs:
   #
   #     - name: Verify built plugin exports every ABI symbol
   #       run: tools/check_abi_compat.sh --abi='${{ matrix.abi }}' --so=build/libbambu_networking.dylib
+  #
+  #     - name: Assert no Homebrew runtime dylib deps
+  #       run: |
+  #         set -eu
+  #         bad=0
+  #         for dylib in build/libbambu_networking.dylib build/libBambuSource.dylib; do
+  #           echo "== otool -L $dylib =="
+  #           otool -L "$dylib"
+  #           if otool -L "$dylib" | grep -E '/opt/homebrew/|/usr/local/opt/'; then
+  #             echo "error: $dylib still links Homebrew paths" >&2
+  #             bad=1
+  #           fi
+  #         done
+  #         exit "$bad"
   #
   #     - name: Stage artifacts
   #       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,16 +220,15 @@ jobs:
       - name: Install build dependencies
         run: |
           set -eu
-          for pkg in pkg-config cmake openssl@3 curl cjson zlib uthash; do
+          # curl/cjson/zlib are NOT brew runtime deps: libcurl is vendored
+          # static, cJSON is vendored with mosquitto, zlib is system.
+          # openssl@3 is build-time only (static .a archives embedded).
+          for pkg in pkg-config cmake openssl@3 uthash; do
             brew list "$pkg" &>/dev/null || brew install "$pkg"
           done
           {
             echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
-            PC="$(brew --prefix openssl@3)/lib/pkgconfig"
-            PC="${PC}:$(brew --prefix curl)/lib/pkgconfig"
-            PC="${PC}:$(brew --prefix zlib)/lib/pkgconfig"
-            PC="${PC}:$(brew --prefix cjson)/lib/pkgconfig"
-            echo "PKG_CONFIG_PATH=${PC}"
+            echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig"
           } >> "$GITHUB_ENV"
 
       - name: Configure
@@ -249,6 +248,22 @@ jobs:
 
       - name: Verify built plugin exports every ABI symbol
         run: tools/check_abi_compat.sh --abi='${{ matrix.abi }}' --so=build/libbambu_networking.dylib
+
+      - name: Assert no Homebrew runtime dylib deps
+        run: |
+          set -eu
+          # Static OpenSSL + vendored curl must leave no /opt/homebrew or
+          # /usr/local/opt NEEDED entries (issue #60).
+          bad=0
+          for dylib in build/libbambu_networking.dylib build/libBambuSource.dylib; do
+            echo "== otool -L $dylib =="
+            otool -L "$dylib"
+            if otool -L "$dylib" | grep -E '/opt/homebrew/|/usr/local/opt/'; then
+              echo "error: $dylib still links Homebrew paths" >&2
+              bad=1
+            fi
+          done
+          exit "$bad"
 
       - name: Stage artifacts
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,21 @@ set(OBN_MOSQUITTO_GIT_TAG "v2.1.2"
     CACHE STRING "Git tag for eclipse/mosquitto (FetchContent)")
 set(OBN_CJSON_GIT_TAG "v1.7.18"
     CACHE STRING "Git tag for DaveGamble/cJSON (FetchContent)")
+# Vendored libcurl (static) used on macOS so the plugin dylib has no
+# runtime NEEDED on Homebrew's libcurl.4.dylib (issue #60).
+set(OBN_CURL_GIT_TAG "curl-8_11_1"
+    CACHE STRING "Git tag for curl/curl (FetchContent, macOS static embed)")
+
+# On macOS, statically embed Homebrew's OpenSSL .a archives and a
+# minimal vendored libcurl.a. Opt out with -DOBN_MACOS_STATIC_DEPS=OFF
+# (then pkg-config libcurl + shared OpenSSL are used, as on Linux).
+if(APPLE)
+    option(OBN_MACOS_STATIC_DEPS
+        "Statically embed OpenSSL + libcurl on macOS (no Homebrew runtime deps)"
+        ON)
+else()
+    set(OBN_MACOS_STATIC_DEPS OFF)
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -228,7 +243,9 @@ endif()
 # --------------------------------------------------------------------------
 
 # Dependency resolution:
-#   - Linux/macOS: pkg-config for libcurl; OpenSSL/zlib via CMake.
+#   - Linux: pkg-config for libcurl; OpenSSL/zlib via CMake.
+#   - macOS (OBN_MACOS_STATIC_DEPS ON, default): Homebrew OpenSSL static
+#     archives + vendored static libcurl (no Homebrew runtime NEEDED).
 #   - Windows: vcpkg manifest for curl/openssl/zlib; mosquitto is always
 #     vendored via FetchContent (same as Linux).
 if(WIN32)
@@ -237,19 +254,41 @@ if(WIN32)
     find_package(CURL CONFIG REQUIRED)
 else()
     find_package(PkgConfig REQUIRED)
+    # Must be set before find_package(OpenSSL) AND before the vendored
+    # curl subdirectory's own find_package(OpenSSL), so both resolve
+    # libssl.a / libcrypto.a from OPENSSL_ROOT_DIR (brew openssl@3).
+    if(APPLE AND OBN_MACOS_STATIC_DEPS)
+        set(OPENSSL_USE_STATIC_LIBS TRUE)
+    endif()
     find_package(OpenSSL COMPONENTS SSL REQUIRED)
     find_package(ZLIB REQUIRED)
+    # Homebrew's static libcrypto.a needs Security.framework at final link.
+    # Attach it to the imported OpenSSL targets so every consumer
+    # (plugin, BambuSource, vendored mosquitto/curl, tests) picks it up.
+    if(APPLE AND OBN_MACOS_STATIC_DEPS)
+        foreach(_obn_ssl_tgt IN ITEMS OpenSSL::SSL OpenSSL::Crypto)
+            if(TARGET ${_obn_ssl_tgt})
+                set_property(TARGET ${_obn_ssl_tgt} APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES "-framework Security")
+            endif()
+        endforeach()
+    endif()
 endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/VendorMosquitto.cmake")
 obn_vendor_mosquitto_setup()
 
-# CURL imported target: PkgConfig::CURL on POSIX, CURL::libcurl on Windows
-# (vcpkg's CURLConfig.cmake exports that name). We expose a unified alias
-# so the per-target target_link_libraries calls below stay platform-free.
+# CURL imported target: PkgConfig::CURL on Linux, vendored static on
+# macOS (OBN_MACOS_STATIC_DEPS), CURL::libcurl on Windows (vcpkg). We
+# expose a unified alias so the per-target target_link_libraries calls
+# below stay platform-free.
 add_library(obn_curl_iface INTERFACE)
 if(WIN32)
     target_link_libraries(obn_curl_iface INTERFACE CURL::libcurl)
+elseif(APPLE AND OBN_MACOS_STATIC_DEPS)
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/VendorCurl.cmake")
+    obn_vendor_curl_setup()
+    target_link_libraries(obn_curl_iface INTERFACE obn_vendor_curl_iface)
 else()
     pkg_check_modules(CURL REQUIRED IMPORTED_TARGET libcurl)
     target_link_libraries(obn_curl_iface INTERFACE PkgConfig::CURL)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ plugin.
     - [Prerequisites](#prerequisites-linux)
     - [Linux: configure, build and install](#linux-configure-build-and-install)
     - [`./configure` options](#configure-options)
+  - [macOS](#macos)
   - [Windows](#windows)
     - [Prerequisites](#prerequisites-windows)
     - [Windows: configure, build and install](#windows-configure-build-and-install)
@@ -107,7 +108,7 @@ Please note:
 - Linux aarch64 (primary target).
 - Windows x64 (experimental).
 - Windows ARM64 (experimental).
-- macOS (very experimental, works partially, not documented yet).
+- macOS (experimental; curl and OpenSSL are statically embedded — no Homebrew runtime dependency).
 
 ## Supported Bambu Studio versions (ABI versions)
 
@@ -397,6 +398,38 @@ The detected `W.X.Y.Z` or `W.X.Y` is turned into a **four-component** `OBN_VERSI
 `./configure --help` also lists less common flags (including Mosquitto linking
 options). Driving **CMake** directly works the same way; see `OBN_`* and
 other cache variables in `CMakeLists.txt`.
+
+### macOS
+
+macOS builds **statically embed** OpenSSL and libcurl into the plugin dylibs
+(`OBN_MACOS_STATIC_DEPS=ON` by default). Homebrew is needed only at **build**
+time for `openssl@3` (static `.a` archives); the installed plugin does **not**
+require `brew install curl` / a Homebrew OpenSSL at runtime
+([issue #60](https://github.com/ClusterM/open-bamboo-networking/issues/60)).
+libcurl itself is vendored from source via FetchContent (minimal OpenSSL +
+system zlib build).
+
+#### Prerequisites (macOS)
+
+```sh
+brew install cmake pkg-config openssl@3 uthash
+```
+
+`./configure` auto-detects `OPENSSL_ROOT_DIR` from `brew --prefix openssl@3`
+when unset. Opt out of the static embed with
+`--cmake-arg=-DOBN_MACOS_STATIC_DEPS=OFF` (then you need a pkg-config
+`libcurl` as on Linux).
+
+#### macOS: configure, build and install
+
+```sh
+./configure
+make
+make install
+```
+
+Default `--prefix` is `~/Library/Application Support/BambuStudio` (or
+`…/OrcaSlicer` with `--client-type=orca_slicer`).
 
 ### Windows
 

--- a/cmake/VendorCurl.cmake
+++ b/cmake/VendorCurl.cmake
@@ -1,0 +1,97 @@
+# Minimal static libcurl via FetchContent for embedding into
+# libbambu_networking.dylib on macOS without a Homebrew libcurl.dylib
+# runtime dependency (issue #60).
+#
+# Build with OpenSSL + system zlib only; disable every optional third-party
+# feature (nghttp2 / brotli / zstd / libpsl / libssh2 / idn2 / ldap) so the
+# archive has no transitive Homebrew NEEDED entries. OpenSSL must already
+# be findable as OpenSSL::SSL / OpenSSL::Crypto (caller sets
+# OPENSSL_USE_STATIC_LIBS + OPENSSL_ROOT_DIR before calling this).
+
+function(obn_vendor_curl_setup)
+    include(FetchContent)
+
+    # FetchContent_Populate is deprecated (CMP0169 NEW)
+    if(POLICY CMP0169)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+
+    # CACHE+FORCE so curl's option() calls (CMP0077 OLD) cannot reset these.
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+    set(BUILD_STATIC_LIBS ON CACHE BOOL "" FORCE)
+    set(BUILD_CURL_EXE OFF CACHE BOOL "" FORCE)
+    set(BUILD_STATIC_CURL OFF CACHE BOOL "" FORCE)
+    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+    set(CURL_ENABLE_EXPORT_TARGET OFF CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_INSTALL ON CACHE BOOL "" FORCE)
+
+    set(CURL_USE_OPENSSL ON CACHE BOOL "" FORCE)
+    set(CURL_ZLIB ON CACHE BOOL "" FORCE)
+    set(USE_NGHTTP2 OFF CACHE BOOL "" FORCE)
+    set(CURL_BROTLI OFF CACHE BOOL "" FORCE)
+    set(CURL_ZSTD OFF CACHE BOOL "" FORCE)
+    set(CURL_USE_LIBPSL OFF CACHE BOOL "" FORCE)
+    set(CURL_USE_LIBSSH2 OFF CACHE BOOL "" FORCE)
+    set(USE_LIBIDN2 OFF CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_LDAP ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_LDAPS ON CACHE BOOL "" FORCE)
+
+    FetchContent_Declare(curl
+        GIT_REPOSITORY https://github.com/curl/curl.git
+        GIT_TAG ${OBN_CURL_GIT_TAG}
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+    )
+
+    FetchContent_GetProperties(curl)
+    if(NOT curl_POPULATED)
+        FetchContent_Populate(curl)
+    endif()
+
+    set(_obn_saved_skip_install "${CMAKE_SKIP_INSTALL_RULES}")
+    set(CMAKE_SKIP_INSTALL_RULES TRUE)
+    add_subdirectory("${curl_SOURCE_DIR}" "${curl_BINARY_DIR}" EXCLUDE_FROM_ALL)
+    set(CMAKE_SKIP_INSTALL_RULES "${_obn_saved_skip_install}")
+
+    # Prefer the explicit static target; fall back to CURL::libcurl_static /
+    # CURL::libcurl when present (curl CMake has renamed aliases across
+    # releases).
+    set(_obn_curl_target "")
+    if(TARGET libcurl_static)
+        set(_obn_curl_target libcurl_static)
+    elseif(TARGET CURL::libcurl_static)
+        set(_obn_curl_target CURL::libcurl_static)
+    elseif(TARGET CURL::libcurl)
+        set(_obn_curl_target CURL::libcurl)
+    endif()
+    if(NOT _obn_curl_target)
+        message(FATAL_ERROR
+            "obn: vendored curl (${OBN_CURL_GIT_TAG}) did not produce a "
+            "static libcurl target (libcurl_static / CURL::libcurl_static)")
+    endif()
+
+    # We only embed the static archive; do not build unused shared libs.
+    if(TARGET libcurl_shared)
+        set_target_properties(libcurl_shared PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endif()
+    if(TARGET curl)
+        set_target_properties(curl PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endif()
+
+    add_library(obn_vendor_curl_iface INTERFACE)
+    target_link_libraries(obn_vendor_curl_iface INTERFACE "${_obn_curl_target}")
+    # Static libcurl on Darwin needs these frameworks (resolver / proxy /
+    # SCDynamicStore). Linking them here keeps consumers platform-free.
+    if(APPLE)
+        target_link_libraries(obn_vendor_curl_iface INTERFACE
+            "-framework SystemConfiguration"
+            "-framework CoreFoundation"
+        )
+    endif()
+    # Match curl's own static-build define so headers do not emit
+    # dllimport-style declarations on any platform.
+    target_compile_definitions(obn_vendor_curl_iface INTERFACE CURL_STATICLIB)
+
+    message(STATUS
+        "obn: using vendored libcurl_static (${OBN_CURL_GIT_TAG}) via ${_obn_curl_target}")
+endfunction()

--- a/configure
+++ b/configure
@@ -159,6 +159,25 @@ EOF
     exit 1
 fi
 
+# macOS static OpenSSL/curl embed (OBN_MACOS_STATIC_DEPS, default ON) needs
+# OPENSSL_ROOT_DIR pointing at brew openssl@3 so FindOpenSSL resolves the
+# static .a archives. CI already exports this; for local ./configure we
+# auto-detect when unset.
+if [ "$(uname -s)" = "Darwin" ] \
+   && [ -z "${OPENSSL_ROOT_DIR:-}" ] \
+   && command -v brew >/dev/null 2>&1
+then
+    _obn_brew_openssl="$(brew --prefix openssl@3 2>/dev/null || true)"
+    if [ -n "$_obn_brew_openssl" ] && [ -d "$_obn_brew_openssl" ]; then
+        EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DOPENSSL_ROOT_DIR=${_obn_brew_openssl}"
+        echo "configure: macOS OPENSSL_ROOT_DIR=${_obn_brew_openssl} (brew openssl@3)"
+    else
+        echo "configure: warning: brew openssl@3 not found; macOS static OpenSSL link may fail." >&2
+        echo "configure:          install with: brew install openssl@3" >&2
+    fi
+    unset _obn_brew_openssl
+fi
+
 # On Linux and macOS, default the install prefix to the per-client config
 # directory when PREFIX is unset. Linux also prefers native ~/.config over
 # Flatpak under ~/.var/app when only one exists.

--- a/configure
+++ b/configure
@@ -163,8 +163,13 @@ fi
 # OPENSSL_ROOT_DIR pointing at brew openssl@3 so FindOpenSSL resolves the
 # static .a archives. CI already exports this; for local ./configure we
 # auto-detect when unset.
+case "$EXTRA_CMAKE_ARGS" in
+    *-DOPENSSL_ROOT_DIR=*|*-DOPENSSL_ROOT_DIR:*) _obn_openssl_root_in_args=1 ;;
+    *) _obn_openssl_root_in_args=0 ;;
+esac
 if [ "$(uname -s)" = "Darwin" ] \
    && [ -z "${OPENSSL_ROOT_DIR:-}" ] \
+   && [ "$_obn_openssl_root_in_args" -eq 0 ] \
    && command -v brew >/dev/null 2>&1
 then
     _obn_brew_openssl="$(brew --prefix openssl@3 2>/dev/null || true)"
@@ -177,6 +182,7 @@ then
     fi
     unset _obn_brew_openssl
 fi
+unset _obn_openssl_root_in_args
 
 # On Linux and macOS, default the install prefix to the per-client config
 # directory when PREFIX is unset. Linux also prefers native ~/.config over

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -36,28 +36,6 @@ case "$OS" in
     *)      die "Unsupported OS: $OS (this installer supports Linux and macOS)" ;;
 esac
 
-# ── macOS: check for Homebrew and curl ───────────────────────────────────
-
-if [ "$OS" = "Darwin" ]; then
-    if ! command -v brew >/dev/null 2>&1; then
-        die "Homebrew is not installed.
-  The plugin requires libcurl from Homebrew. Install Homebrew first:
-    /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"
-  Then install curl:
-    brew install curl
-  and re-run this installer."
-    fi
-
-    if ! brew list curl >/dev/null 2>&1; then
-        die "curl is not installed via Homebrew.
-  The plugin requires libcurl from Homebrew (the system curl may lack OpenSSL support).
-  Install it with:
-    brew install curl
-  and re-run this installer."
-    fi
-    info "Homebrew curl found: $(brew --prefix curl)/lib"
-fi
-
 # ── Client selection ─────────────────────────────────────────────────────
 
 printf "\n${BOLD}Open Bamboo Networking — Installer${RESET}\n"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes macOS TLS/HTTP linking and vendored curl build flags; mistakes could break HTTPS/MQTT on macOS or reintroduce Homebrew NEEDED entries, though CI `otool` checks mitigate the latter.
> 
> **Overview**
> **macOS plugin dylibs no longer need Homebrew `curl` or OpenSSL at runtime** (issue #60). By default, `OBN_MACOS_STATIC_DEPS=ON` links **static** Homebrew `openssl@3` archives and a **FetchContent** minimal `libcurl` (`cmake/VendorCurl.cmake`, tag `curl-8_11_1`) into `libbambu_networking.dylib` / `libBambuSource.dylib`, with `Security` / `SystemConfiguration` / `CoreFoundation` wired where static linking requires them. Linux and `OBN_MACOS_STATIC_DEPS=OFF` still use pkg-config libcurl and shared OpenSSL.
> 
> **CI and packaging** drop brew `curl`/`cjson`/`zlib` from macOS jobs, narrow `PKG_CONFIG_PATH` to OpenSSL, and add an **`otool -L` gate** that fails if `/opt/homebrew` or `/usr/local/opt` appear on the main dylibs. **`./configure`** auto-sets `OPENSSL_ROOT_DIR` from `brew --prefix openssl@3` on Darwin; **`packaging/install.sh`** no longer blocks install when Homebrew curl is missing. **README** documents macOS prerequisites and the static-embed default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682c1e5eb108a0b9d8c76d1d8b84eb3d81abc4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->