### PR TITLE
Added macOS BambuPlayer adapter and H.264 AVCC support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,11 @@ jobs:
       - name: Verify built plugin exports every ABI symbol
         run: tools/check_abi_compat.sh --abi='${{ matrix.abi }}' --so=build/libbambu_networking.dylib
 
+      - name: Verify BambuPlayer ObjC class is exported
+        run: |
+          set -eu
+          nm -gU build/libBambuSource.dylib | grep '_OBJC_CLASS_\$_BambuPlayer'
+
       - name: Stage artifacts
         run: |
           set -eu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,11 @@ jobs:
       - name: Verify built plugin exports every ABI symbol
         run: tools/check_abi_compat.sh --abi='${{ matrix.abi }}' --so=build/libbambu_networking.dylib
 
+      - name: Verify BambuPlayer ObjC class is exported
+        run: |
+          set -eu
+          nm -gU build/libBambuSource.dylib | grep '_OBJC_CLASS_\$_BambuPlayer'
+
       - name: Stage artifacts
         run: |
           set -eu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(open-bamboo-networking
     LANGUAGES C CXX
 )
 
+# macOS BambuPlayer adapter (stubs/BambuPlayer.mm) is Objective-C++.
+if(APPLE)
+    enable_language(OBJCXX)
+endif()
+
 # Vendored mosquitto pulls cJSON via FetchContent; released cJSON tags still
 # declare cmake_minimum_required(VERSION 3.0) or older. CMake 3.31+ rejects
 # that unless we raise the policy floor (same effect as -DCMAKE_POLICY_VERSION_MINIMUM=3.5).
@@ -401,6 +406,7 @@ set(_obn_bambusource_sources
     stubs/tls_socket.cpp
     stubs/rtsp_client.cpp
     stubs/rtsp_passthrough.cpp
+    stubs/h264_avcc.cpp
     src/config.cpp
     src/ftps.cpp
     src/json_lite.cpp
@@ -420,6 +426,14 @@ if(WIN32)
         stubs/BambuSource.def
     )
 endif()
+if(APPLE)
+    # MRC required: wxMediaCtrl2::~wxMediaCtrl2 calls [player dealloc]
+    # directly. Keep -fno-objc-arc on this translation unit only.
+    list(APPEND _obn_bambusource_sources stubs/BambuPlayer.mm)
+    set_source_files_properties(stubs/BambuPlayer.mm PROPERTIES
+        COMPILE_OPTIONS "-fno-objc-arc"
+    )
+endif()
 
 add_library(BambuSource SHARED ${_obn_bambusource_sources})
 # `src` is on the include path for src/ftps.cpp's private ftps_parse.hpp.
@@ -431,6 +445,17 @@ if(WIN32)
         ws2_32 crypt32 secur32 bcrypt iphlpapi
         strmiids ole32 oleaut32 uuid
         advapi32 shell32 user32
+    )
+elseif(APPLE)
+    set_target_properties(BambuSource PROPERTIES OUTPUT_NAME "BambuSource" PREFIX "lib")
+    target_link_libraries(BambuSource PRIVATE
+        OpenSSL::SSL OpenSSL::Crypto
+        "-framework Foundation"
+        "-framework Cocoa"
+        "-framework QuartzCore"
+        "-framework AVFoundation"
+        "-framework CoreMedia"
+        "-framework CoreVideo"
     )
 else()
     set_target_properties(BambuSource PROPERTIES OUTPUT_NAME "BambuSource" PREFIX "lib")
@@ -692,6 +717,12 @@ if(OBN_BUILD_TESTS AND NOT WIN32)
     target_include_directories(tunnel_local_test PRIVATE include stubs ${OBN_GENERATED_DIR})
     target_link_libraries(tunnel_local_test PRIVATE OpenSSL::SSL OpenSSL::Crypto)
     add_test(NAME tunnel_local COMMAND tunnel_local_test)
+
+    # Portable Annex-B → AVCC helper used by the macOS BambuPlayer adapter.
+    add_executable(h264_avcc_test tests/h264_avcc_test.cpp
+        stubs/h264_avcc.cpp)
+    target_include_directories(h264_avcc_test PRIVATE stubs)
+    add_test(NAME h264_avcc COMMAND h264_avcc_test)
 
     # Hermetic unit test for obn::auth::Store persistence, specifically
     # the firmware_beta_open field (profile setting.isFirmwareBetaOpen)

--- a/STATUS.md
+++ b/STATUS.md
@@ -465,14 +465,14 @@ The build is intentionally minimal-dependency: only OpenSSL and zlib, **no `liba
 | `Bambu_SendMessage` | ✅ | Used by the file-browser path to enqueue CTRL JSON requests. |
 | `Bambu_SetLogger` | ✅ | Stored on the tunnel; routed through the same level-aware sink the rest of the library uses (see [README — `libBambuSource.so` logging](README.md#libbambusourceso-logging)). |
 | `Bambu_GetLastErrorMsg` | ✅ | Thread-local last-error string, populated by every TLS / RTSP / FTPS error site. |
-| `OBJC_CLASS_$_BambuPlayer` (macOS) | ❌ | Not exported. macOS Studio's camera tab will sit at `MEDIASTATE_LOADING` because the dlsym fails (Studio explicitly handles a missing symbol — no crash). The CTRL/file-browser path through `Bambu_*` keeps working on macOS. |
+| `OBJC_CLASS_$_BambuPlayer` (macOS) | ✅ | Clean-room Objective-C++ adapter in [`stubs/BambuPlayer.mm`](stubs/BambuPlayer.mm) (MRC, `-fno-objc-arc`; `@interface` marked `visibility("default")` so `dlsym` finds it under global `-fvisibility=hidden`). Reuses the existing `Bambu_*` C ABI for RTSPS/H.264 Annex-B; converts to AVCC and renders via `AVSampleBufferDisplayLayer`. Optional Studio callbacks (`setTrackReporter` / `setFirstFrameCallback` / `setSessionEndCallback`) implemented. MJPEG `:6000` is rejected (`-3`) — X1/P1S/P2S use RTSPS. End-to-end hardware validation pending (issue [#68](https://github.com/ClusterM/open-bamboo-networking/issues/68) tester). |
 
 ### Camera live view (per camera protocol)
 
 | Camera transport | Applies to | Status | Notes |
 | --- | --- | :--: | --- |
 | MJPEG over TLS, port 6000 | A1 / A1 mini / P1 / P1P | ✅ (not tested) | TLS + 80-byte auth + 16-byte framed JPEG samples. Linux: passes JPEG bytes through to `gstbambusrc`'s `jpegdec`. Windows: same JPEG payload pushed through our DShow source filter as `MEDIASUBTYPE_MJPG`. No A-series hardware available for on-device verification. |
-| RTSPS → H.264 byte-stream, port 322 | X1 / X1C / X1E / P1S / P2S / H-series / X2D | ✅ (tested P2S/N7: Linux Orca, Windows Bambu Studio `wxMediaCtrl3`, Windows Orca DShow) | Custom in-process RTSP/RTSPS client with LAN TLS verify (see §8.4.1); raw H.264 Annex-B byte stream out. Linux: `gstbambusrc` → `h264parse + avdec_h264 / openh264dec`. Windows Studio: FFmpeg `AVVideoDecoder`. Windows Orca: DShow `MEDIASUBTYPE_H264`. |
+| RTSPS → H.264 byte-stream, port 322 | X1 / X1C / X1E / P1S / P2S / H-series / X2D | ✅ (tested P2S/N7: Linux Orca, Windows Bambu Studio `wxMediaCtrl3`, Windows Orca DShow; macOS BambuPlayer built — hardware validation pending) | Custom in-process RTSP/RTSPS client with LAN TLS verify (see §8.4.1); raw H.264 Annex-B byte stream out. Linux: `gstbambusrc` → `h264parse + avdec_h264 / openh264dec`. Windows Studio: FFmpeg `AVVideoDecoder`. Windows Orca: DShow `MEDIASUBTYPE_H264`. macOS: `BambuPlayer` → AVCC → `AVSampleBufferDisplayLayer`. |
 | Cloud camera (TUTK / Agora p2p) | any printer over WAN | 🔒 | Proprietary SDK; out of scope. Stays on the LAN/Developer-Mode path. |
 
 ### PrinterFileSystem (MediaFilePanel)
@@ -544,7 +544,7 @@ If you touch the DirectShow source filter or the `Bambu_*` path on Windows, thre
 
 | Feature | Status | Notes |
 | --- | :--: | --- |
-| Objective-C `BambuPlayer` class | ❌ | Required for camera live view on macOS; not shipped. The `Bambu_*` C ABI for the file browser still works on macOS once the dylib is built. |
+| Objective-C `BambuPlayer` class | ✅ | Required for camera live view on macOS (`wxMediaCtrl2.mm` → `dlsym(…, "OBJC_CLASS_$_BambuPlayer")`). Shipped in `libBambuSource.dylib` ([`stubs/BambuPlayer.mm`](stubs/BambuPlayer.mm)): MRC (`-fno-objc-arc`, Studio calls `[player dealloc]` directly), `visibility("default")` on the `@interface`, Annex-B→AVCC helper in [`stubs/h264_avcc.cpp`](stubs/h264_avcc.cpp). Shared `parse_url` accepts wxURI slash-collapse (`bambu://rtsps___…`). CI asserts the class symbol with `nm`. Hardware LiveView validation tracked in issue [#68](https://github.com/ClusterM/open-bamboo-networking/issues/68). |
 
 ---
 

--- a/research/09.04-camera-backends.md
+++ b/research/09.04-camera-backends.md
@@ -163,6 +163,13 @@ Studio drives it from `wxMediaCtrl2::Load` / `Play` / `Stop` (`wxMediaCtrl2.mm:8
 - `Stop()` → `[player close]`, posts `wxMEDIASTATE_STOPPED`.
 - `GetVideoSize()` → `[player videoSize]`.
 
+**ABI constraints inferred from Studio's call sites** (Orca + BambuStudio `wxMediaCtrl2.mm`):
+
+1. **Manual retain/release (MRC).** Both Orca and Studio destructors call `[player dealloc]` directly (`wxMediaCtrl2.mm` destructor). An ARC-compiled class will double-free or crash; the dylib must build the player translation unit with `-fno-objc-arc`.
+2. **`wxURI` slash-collapse on macOS too.** `open:` receives `url.BuildURI().ToUTF8()`, so the same `bambu:///rtsps___…` → `bambu://rtsps___…` normalisation documented for Windows DirectShow (§9.4.2) applies. The plugin's URL parser must accept any number of `/` after `bambu:`.
+3. **Logger semantics.** `setLogger:withContext:` registers `void(*)(void const*, int level, char const* msg)`. Studio treats `level < 0` as stream-stopped (`NotifyStopped`), and `level == 1` messages ending in `[N]` as `m_error = N`.
+4. **Optional Studio-only selectors.** Current BambuStudio additionally probes `setTrackReporter:withContext:`, `setFirstFrameCallback:withContext:`, and `setSessionEndCallback:withContext:` via `respondsToSelector:` before calling them. Orca 2.4.2 does not. A compatible class may omit them; implementing them is optional telemetry.
+
 Failure mode if the symbol is missing: `m_error = -2`, `m_player = nullptr`. Subsequent `Load` / `Play` calls log `create_player failed currently!` and return without ever transitioning out of `MEDIASTATE_LOADING`. The user sees an **infinite "Loading…" spinner** in the camera tab, *not* the "Player is malfunctioning" dialog — the latter is reserved for `m_failed_code == 2`, which only fires after a state transition that never happens here. (`MediaPlayCtrl.cpp:29-36, 415-428`.)
 
 This is the reason a C-ABI-only `libBambuSource.dylib` build (no Objective-C `BambuPlayer` class) is enough for the Mac file browser but produces an indefinite loading state in the Mac camera tab. To make the camera tab work on macOS the dylib must additionally export an Objective-C class symbol `OBJC_CLASS_$_BambuPlayer` whose interface matches `BambuPlayer.h` above.

--- a/stubs/BambuPlayer.mm
+++ b/stubs/BambuPlayer.mm
@@ -1,0 +1,788 @@
+// Clean-room Objective-C++ BambuPlayer for macOS LAN LiveView.
+//
+// OrcaSlicer / Bambu Studio wxMediaCtrl2.mm looks up this class with
+//   dlsym(libBambuSource.dylib, "OBJC_CLASS_$_BambuPlayer")
+// and drives LAN camera playback through it. Transport and Annex-B
+// production reuse the existing Bambu_* C ABI in this same dylib;
+// this file only owns display (AVSampleBufferDisplayLayer) and the
+// ObjC lifecycle Studio expects.
+//
+// Compiled with -fno-objc-arc (MRC): wxMediaCtrl2::~wxMediaCtrl2 calls
+// [player dealloc] directly.
+
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
+#import <AVFoundation/AVSampleBufferDisplayLayer.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+
+#include "h264_avcc.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Minimal Bambu_* C ABI declarations (same dylib; stubs/BambuSource.cpp).
+// ---------------------------------------------------------------------------
+
+extern "C" {
+
+typedef void* Bambu_Tunnel;
+
+enum Bambu_Error {
+    Bambu_success      = 0,
+    Bambu_stream_end   = 1,
+    Bambu_would_block  = 2,
+    Bambu_buffer_limit = 3,
+};
+
+struct Bambu_Sample {
+    int                  itrack;
+    int                  size;
+    int                  flags;
+    unsigned char const* buffer;
+    unsigned long long   decode_time;
+};
+
+struct Bambu_StreamInfo {
+    int type;
+    int sub_type;
+    union {
+        struct { int width; int height; int frame_rate; } video;
+        struct { int sample_rate; int channel_count; int sample_size; } audio;
+    } format;
+    int                  format_type;
+    int                  format_size;
+    int                  max_frame_size;
+    unsigned char const* format_buffer;
+};
+
+using Bambu_Logger = void (*)(void* context, int level, char const* msg);
+
+int          Bambu_Create(Bambu_Tunnel* tunnel, char const* path);
+void         Bambu_Destroy(Bambu_Tunnel tunnel);
+void         Bambu_SetLogger(Bambu_Tunnel tunnel, Bambu_Logger logger, void* context);
+int          Bambu_Open(Bambu_Tunnel tunnel);
+int          Bambu_StartStream(Bambu_Tunnel tunnel, bool video);
+int          Bambu_GetStreamInfo(Bambu_Tunnel tunnel, int index, Bambu_StreamInfo* info);
+int          Bambu_ReadSample(Bambu_Tunnel tunnel, Bambu_Sample* sample);
+void         Bambu_Close(Bambu_Tunnel tunnel);
+char const*  Bambu_GetLastErrorMsg();
+
+} // extern "C"
+
+// ---------------------------------------------------------------------------
+// Clean-room structs matching Studio's BambuPlayer.h / BambuTunnel.h layout
+// (reconstructed from wxMediaCtrl2.mm field usage — not copied from GPL).
+// ---------------------------------------------------------------------------
+
+typedef struct __PlayerEventC {
+    const char* event_name;
+    const char* module;
+    const char* phase;
+    const char* result;
+    const char* error_code;
+    const char* error_message;
+    const char* event_data_body;
+} PlayerEventC;
+
+typedef struct {
+    int64_t first_packet_ms;
+    int64_t decode_ms;
+    int64_t render_ms;
+    int     codec;
+    int     width;
+    int     height;
+} BambuFirstFrameInfo;
+
+typedef struct {
+    long long session_duration_ms;
+    long long freeze_total_ms;
+    int       freeze_count;
+    float     avg_fps;
+    float     avg_bitrate_kbps;
+    float     avg_jitter_ms;
+    float     max_jitter_ms;
+} BambuSessionEndInfo;
+
+using PlayerLoggerFn =
+    void (*)(void const* context, int level, char const* msg);
+using TrackReporterFn =
+    void (*)(void* ctx, const PlayerEventC* event);
+using FirstFrameFn =
+    void (*)(void const* ctx, const BambuFirstFrameInfo* info);
+using SessionEndFn =
+    void (*)(void const* ctx, const BambuSessionEndInfo* info);
+
+// ---------------------------------------------------------------------------
+// C++ state (ObjC ivars cannot host non-trivial C++ types safely).
+// ---------------------------------------------------------------------------
+
+struct BambuPlayerImpl {
+    Bambu_Tunnel   tunnel = nullptr;
+    std::thread*   reader = nullptr;
+    std::atomic<bool> running{false};
+    // recursive: display helpers may log while already holding mu
+    std::recursive_mutex mu;
+
+    PlayerLoggerFn  logger = nullptr;
+    void const*     loggerCtx = nullptr;
+    TrackReporterFn trackReporter = nullptr;
+    void*           trackCtx = nullptr;
+    FirstFrameFn    firstFrameCb = nullptr;
+    void const*     firstFrameCtx = nullptr;
+    SessionEndFn    sessionEndCb = nullptr;
+    void const*     sessionEndCtx = nullptr;
+
+    CMVideoFormatDescriptionRef formatDesc = nullptr;
+    std::vector<uint8_t> sps;
+    std::vector<uint8_t> pps;
+    int videoW = 0;
+    int videoH = 0;
+
+    std::chrono::steady_clock::time_point openTime{};
+    std::chrono::steady_clock::time_point sessionStart{};
+    std::chrono::steady_clock::time_point lastFrameTime{};
+    bool     gotFirstPacket = false;
+    bool     gotFirstFrame  = false;
+    bool     sessionReported = false;
+    int64_t  firstPacketMs = 0;
+    int64_t  firstDecodeMs = 0;
+    uint64_t frameCount = 0;
+    uint64_t byteCount  = 0;
+    int      freezeCount = 0;
+    long long freezeTotalMs = 0;
+    double   jitterSumMs = 0.0;
+    float    maxJitterMs = 0.f;
+
+    ~BambuPlayerImpl()
+    {
+        if (formatDesc) {
+            CFRelease(formatDesc);
+            formatDesc = nullptr;
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// BambuPlayer
+// ---------------------------------------------------------------------------
+
+__attribute__((visibility("default")))
+@interface BambuPlayer : NSObject {
+    NSView*                     _imageView;
+    AVSampleBufferDisplayLayer* _displayLayer;
+    BOOL                        _ownsDisplayLayer;
+    BambuPlayerImpl*            _impl;
+}
+
++ (void)initialize;
+
+- (instancetype)initWithDisplayLayer:(AVSampleBufferDisplayLayer*)layer;
+- (instancetype)initWithImageView:(NSView*)view;
+- (int)open:(char const*)url;
+- (NSSize)videoSize;
+- (int)play;
+- (void)stop;
+- (void)close;
+
+- (void)setLogger:(PlayerLoggerFn)logger withContext:(void const*)context;
+- (void)setTrackReporter:(TrackReporterFn)reporter withContext:(void*)ctx;
+- (void)setFirstFrameCallback:(FirstFrameFn)cb withContext:(void const*)ctx;
+- (void)setSessionEndCallback:(SessionEndFn)cb withContext:(void const*)ctx;
+
+@end
+
+@implementation BambuPlayer
+
++ (void)initialize
+{
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) return nil;
+    _impl = new BambuPlayerImpl();
+    _ownsDisplayLayer = NO;
+    return self;
+}
+
+- (instancetype)initWithDisplayLayer:(AVSampleBufferDisplayLayer*)layer
+{
+    self = [self init];
+    if (!self) return nil;
+    _displayLayer = [layer retain];
+    _ownsDisplayLayer = NO;
+    return self;
+}
+
+- (instancetype)initWithImageView:(NSView*)view
+{
+    self = [self init];
+    if (!self) return nil;
+    _imageView = [view retain];
+
+    void (^setup)(void) = ^{
+        if (!_imageView.layer) {
+            _imageView.layer = [[[CALayer alloc] init] autorelease];
+            _imageView.wantsLayer = YES;
+        }
+        AVSampleBufferDisplayLayer* layer =
+            [[AVSampleBufferDisplayLayer alloc] init];
+        layer.videoGravity = AVLayerVideoGravityResizeAspect;
+        layer.frame = _imageView.bounds;
+        layer.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+        [_imageView.layer addSublayer:layer];
+        _displayLayer = layer;
+        _ownsDisplayLayer = YES;
+    };
+    if ([NSThread isMainThread]) setup();
+    else dispatch_sync(dispatch_get_main_queue(), setup);
+    return self;
+}
+
+- (void)dealloc
+{
+    [self close];
+    delete _impl;
+    _impl = nullptr;
+    if (_displayLayer) {
+        if (_ownsDisplayLayer) {
+            [_displayLayer removeFromSuperlayer];
+        }
+        [_displayLayer release];
+        _displayLayer = nil;
+    }
+    [_imageView release];
+    _imageView = nil;
+    [super dealloc];
+}
+
+// ---- callbacks ----------------------------------------------------------
+
+- (void)setLogger:(PlayerLoggerFn)logger withContext:(void const*)context
+{
+    std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+    _impl->logger    = logger;
+    _impl->loggerCtx = context;
+}
+
+- (void)setTrackReporter:(TrackReporterFn)reporter withContext:(void*)ctx
+{
+    std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+    _impl->trackReporter = reporter;
+    _impl->trackCtx      = ctx;
+}
+
+- (void)setFirstFrameCallback:(FirstFrameFn)cb withContext:(void const*)ctx
+{
+    std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+    _impl->firstFrameCb  = cb;
+    _impl->firstFrameCtx = ctx;
+}
+
+- (void)setSessionEndCallback:(SessionEndFn)cb withContext:(void const*)ctx
+{
+    std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+    _impl->sessionEndCb  = cb;
+    _impl->sessionEndCtx = ctx;
+}
+
+- (void)logAt:(int)level message:(char const*)msg
+{
+    PlayerLoggerFn fn = nullptr;
+    void const*    ctx = nullptr;
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        fn  = _impl->logger;
+        ctx = _impl->loggerCtx;
+    }
+    if (fn && msg) fn(ctx, level, msg);
+}
+
+- (void)emitTrack:(char const*)name
+            phase:(char const*)phase
+           result:(char const*)result
+            error:(char const*)error
+{
+    TrackReporterFn fn = nullptr;
+    void*           ctx = nullptr;
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        fn  = _impl->trackReporter;
+        ctx = _impl->trackCtx;
+    }
+    if (!fn || !name) return;
+    PlayerEventC ev{};
+    ev.event_name      = name;
+    ev.module          = "BambuPlayer";
+    ev.phase           = phase;
+    ev.result          = result;
+    ev.error_code      = error;
+    ev.error_message   = error;
+    ev.event_data_body = nullptr;
+    fn(ctx, &ev);
+}
+
+static void bambu_logger_bridge(void* context, int level, char const* msg)
+{
+    BambuPlayer* self = static_cast<BambuPlayer*>(context);
+    if (!self) return;
+    if (!msg) {
+        [self logAt:level message:""];
+        return;
+    }
+    // Sanitize access-code material before it reaches Studio logs.
+    std::string s(msg);
+    auto redact = [&](const char* key) {
+        const std::string k = key;
+        size_t pos = 0;
+        while ((pos = s.find(k, pos)) != std::string::npos) {
+            size_t val = pos + k.size();
+            size_t end = s.find_first_of("& \t\n\r\"'", val);
+            if (end == std::string::npos) end = s.size();
+            s.replace(val, end - val, "***");
+            pos = val + 3;
+        }
+    };
+    redact("passwd=");
+    redact("password=");
+    [self logAt:level message:s.c_str()];
+}
+
+// ---- lifecycle ----------------------------------------------------------
+
+- (NSSize)videoSize
+{
+    std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+    if (_impl->videoW > 0 && _impl->videoH > 0)
+        return NSMakeSize(_impl->videoW, _impl->videoH);
+    if (_impl->formatDesc) {
+        CMVideoDimensions d =
+            CMVideoFormatDescriptionGetDimensions(_impl->formatDesc);
+        if (d.width > 0 && d.height > 0)
+            return NSMakeSize(d.width, d.height);
+    }
+    return NSMakeSize(0, 0);
+}
+
+- (int)open:(char const*)url
+{
+    [self close];
+    if (!url || !*url) {
+        [self logAt:1 message:"open: empty url [-1]"];
+        return -1;
+    }
+
+    Bambu_Tunnel tunnel = nullptr;
+    int rc = Bambu_Create(&tunnel, url);
+    if (rc != Bambu_success || !tunnel) {
+        [self logAt:1 message:"open: Bambu_Create failed [-1]"];
+        [self emitTrack:"liveview_open" phase:"create" result:"fail" error:"create"];
+        return -1;
+    }
+    Bambu_SetLogger(tunnel, bambu_logger_bridge, self);
+
+    rc = Bambu_Open(tunnel);
+    if (rc != Bambu_success) {
+        Bambu_Destroy(tunnel);
+        char buf[256];
+        snprintf(buf, sizeof(buf), "open: Bambu_Open failed [%d]", rc);
+        [self logAt:1 message:buf];
+        [self emitTrack:"liveview_open" phase:"open" result:"fail" error:"open"];
+        return rc < 0 ? rc : -1;
+    }
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    for (;;) {
+        rc = Bambu_StartStream(tunnel, true);
+        if (rc != Bambu_would_block) break;
+        if (std::chrono::steady_clock::now() >= deadline) {
+            Bambu_Close(tunnel);
+            Bambu_Destroy(tunnel);
+            [self logAt:1 message:"open: StartStream timeout [-1]"];
+            [self emitTrack:"liveview_open" phase:"start" result:"fail" error:"timeout"];
+            return -1;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    if (rc != Bambu_success) {
+        Bambu_Close(tunnel);
+        Bambu_Destroy(tunnel);
+        char buf[256];
+        snprintf(buf, sizeof(buf), "open: Bambu_StartStream failed [%d]", rc);
+        [self logAt:1 message:buf];
+        [self emitTrack:"liveview_open" phase:"start" result:"fail" error:"start"];
+        return rc < 0 ? rc : -1;
+    }
+
+    Bambu_StreamInfo info{};
+    if (Bambu_GetStreamInfo(tunnel, 0, &info) == Bambu_success) {
+        if (info.format.video.width > 0)  _impl->videoW = info.format.video.width;
+        if (info.format.video.height > 0) _impl->videoH = info.format.video.height;
+        // format_type 2 = video_jpeg — ASBDL cannot display JPEG samples.
+        if (info.format_type == 2 /*video_jpeg*/) {
+            Bambu_Close(tunnel);
+            Bambu_Destroy(tunnel);
+            [self logAt:1 message:"open: MJPEG not supported by BambuPlayer [-3]"];
+            [self emitTrack:"liveview_open" phase:"format" result:"fail" error:"mjpeg"];
+            return -3;
+        }
+    }
+
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        _impl->tunnel          = tunnel;
+        _impl->openTime        = std::chrono::steady_clock::now();
+        _impl->sessionStart    = _impl->openTime;
+        _impl->gotFirstPacket  = false;
+        _impl->gotFirstFrame   = false;
+        _impl->sessionReported = false;
+        _impl->firstPacketMs   = 0;
+        _impl->firstDecodeMs   = 0;
+        _impl->frameCount      = 0;
+        _impl->byteCount       = 0;
+        _impl->freezeCount     = 0;
+        _impl->freezeTotalMs   = 0;
+        _impl->jitterSumMs     = 0.0;
+        _impl->maxJitterMs     = 0.f;
+        _impl->sps.clear();
+        _impl->pps.clear();
+        if (_impl->formatDesc) {
+            CFRelease(_impl->formatDesc);
+            _impl->formatDesc = nullptr;
+        }
+    }
+
+    [self emitTrack:"liveview_open" phase:"open" result:"ok" error:nullptr];
+    [self logAt:0 message:"open: ok"];
+    return 0;
+}
+
+- (int)play
+{
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        if (!_impl->tunnel) {
+            [self logAt:1 message:"play: no open tunnel [-1]"];
+            return -1;
+        }
+        if (_impl->running.load()) return 0;
+        _impl->running.store(true);
+        _impl->sessionStart  = std::chrono::steady_clock::now();
+        _impl->lastFrameTime = _impl->sessionStart;
+        if (_impl->reader) {
+            delete _impl->reader;
+            _impl->reader = nullptr;
+        }
+        _impl->reader = new std::thread([self] { [self readerLoop]; });
+    }
+    [self emitTrack:"liveview_play" phase:"play" result:"ok" error:nullptr];
+    return 0;
+}
+
+- (void)stop
+{
+    [self close];
+}
+
+- (void)close
+{
+    _impl->running.store(false);
+
+    std::thread* thr = nullptr;
+    Bambu_Tunnel tunnel = nullptr;
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        thr = _impl->reader;
+        _impl->reader = nullptr;
+        tunnel = _impl->tunnel;
+        _impl->tunnel = nullptr;
+    }
+
+    if (thr) {
+        if (thr->joinable()) thr->join();
+        delete thr;
+    }
+
+    if (tunnel) {
+        Bambu_Close(tunnel);
+        Bambu_Destroy(tunnel);
+    }
+
+    AVSampleBufferDisplayLayer* layer = _displayLayer;
+    if (layer) {
+        void (^flush)(void) = ^{
+            if ([layer respondsToSelector:@selector(flushAndRemoveImage)])
+                [layer flushAndRemoveImage];
+            else
+                [layer flush];
+        };
+        if ([NSThread isMainThread]) flush();
+        else dispatch_sync(dispatch_get_main_queue(), flush);
+    }
+
+    [self fireSessionEndIfNeeded];
+}
+
+- (void)fireSessionEndIfNeeded
+{
+    SessionEndFn cb = nullptr;
+    void const*  ctx = nullptr;
+    BambuSessionEndInfo info{};
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        if (_impl->sessionReported) return;
+        if (_impl->frameCount == 0 && !_impl->gotFirstFrame) return;
+        _impl->sessionReported = true;
+        cb  = _impl->sessionEndCb;
+        ctx = _impl->sessionEndCtx;
+        auto now = std::chrono::steady_clock::now();
+        info.session_duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - _impl->sessionStart).count();
+        info.freeze_total_ms = _impl->freezeTotalMs;
+        info.freeze_count    = _impl->freezeCount;
+        if (info.session_duration_ms > 0 && _impl->frameCount > 0) {
+            info.avg_fps = static_cast<float>(
+                (1000.0 * static_cast<double>(_impl->frameCount)) /
+                static_cast<double>(info.session_duration_ms));
+            info.avg_bitrate_kbps = static_cast<float>(
+                (8.0 * static_cast<double>(_impl->byteCount) / 1000.0) /
+                (static_cast<double>(info.session_duration_ms) / 1000.0));
+        }
+        if (_impl->frameCount > 1) {
+            info.avg_jitter_ms = static_cast<float>(
+                _impl->jitterSumMs / static_cast<double>(_impl->frameCount - 1));
+        }
+        info.max_jitter_ms = _impl->maxJitterMs;
+    }
+    if (cb) cb(ctx, &info);
+    [self emitTrack:"liveview_session_end" phase:"close" result:"ok" error:nullptr];
+}
+
+// ---- reader / display ---------------------------------------------------
+
+- (BOOL)ensureFormatDescWithSps:(const std::vector<uint8_t>&)sps
+                            pps:(const std::vector<uint8_t>&)pps
+{
+    // Caller holds _impl->mu.
+    if (sps.empty() || pps.empty()) return NO;
+    if (_impl->formatDesc && sps == _impl->sps && pps == _impl->pps) return YES;
+
+    const uint8_t* sets[2]  = { sps.data(), pps.data() };
+    size_t         sizes[2] = { sps.size(), pps.size() };
+    CMVideoFormatDescriptionRef desc = nullptr;
+    OSStatus st = CMVideoFormatDescriptionCreateFromH264ParameterSets(
+        kCFAllocatorDefault, 2, sets, sizes, 4, &desc);
+    if (st != noErr || !desc) {
+        char buf[128];
+        snprintf(buf, sizeof(buf), "formatDesc create failed status=%d", (int)st);
+        [self logAt:1 message:buf];
+        return NO;
+    }
+    if (_impl->formatDesc) CFRelease(_impl->formatDesc);
+    _impl->formatDesc = desc;
+    _impl->sps = sps;
+    _impl->pps = pps;
+    CMVideoDimensions d = CMVideoFormatDescriptionGetDimensions(desc);
+    if (d.width > 0 && d.height > 0) {
+        _impl->videoW = d.width;
+        _impl->videoH = d.height;
+    }
+    return YES;
+}
+
+- (BOOL)enqueueAnnexB:(const uint8_t*)data
+                 size:(size_t)size
+                 sync:(BOOL)isSync
+{
+    obn::h264::ParameterSets ps;
+    const bool havePs = obn::h264::extract_parameter_sets(data, size, &ps);
+
+    CMVideoFormatDescriptionRef fmt = nullptr;
+    AVSampleBufferDisplayLayer* layer = nil;
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        if (havePs) {
+            if (![self ensureFormatDescWithSps:ps.sps pps:ps.pps]) return NO;
+        }
+        fmt   = _impl->formatDesc;
+        layer = _displayLayer;
+        if (!fmt || !layer) return NO;
+        CFRetain(fmt);
+        [layer retain];
+    }
+
+    obn::h264::AvccFrame avcc;
+    if (!obn::h264::annexb_to_avcc(data, size, &avcc)) {
+        CFRelease(fmt);
+        [layer release];
+        return NO;
+    }
+
+    CMBlockBufferRef block = nullptr;
+    OSStatus st = CMBlockBufferCreateWithMemoryBlock(
+        kCFAllocatorDefault, nullptr, avcc.data.size(),
+        kCFAllocatorDefault, nullptr, 0, avcc.data.size(),
+        kCMBlockBufferAssureMemoryNowFlag, &block);
+    if (st != noErr || !block) {
+        CFRelease(fmt);
+        [layer release];
+        return NO;
+    }
+    st = CMBlockBufferReplaceDataBytes(avcc.data.data(), block, 0, avcc.data.size());
+    if (st != noErr) {
+        CFRelease(block);
+        CFRelease(fmt);
+        [layer release];
+        return NO;
+    }
+
+    CMSampleBufferRef sample = nullptr;
+    size_t sampleSize = avcc.data.size();
+    CMSampleTimingInfo timing;
+    timing.duration              = kCMTimeInvalid;
+    timing.presentationTimeStamp = kCMTimeInvalid;
+    timing.decodeTimeStamp       = kCMTimeInvalid;
+    st = CMSampleBufferCreateReady(
+        kCFAllocatorDefault, block, fmt, 1, 1, &timing, 1, &sampleSize, &sample);
+    CFRelease(block);
+    CFRelease(fmt);
+    if (st != noErr || !sample) {
+        [layer release];
+        return NO;
+    }
+
+    CFArrayRef attachments = CMSampleBufferGetSampleAttachmentsArray(sample, true);
+    if (attachments && CFArrayGetCount(attachments) > 0) {
+        CFMutableDictionaryRef dict =
+            (CFMutableDictionaryRef)CFArrayGetValueAtIndex(attachments, 0);
+        CFDictionarySetValue(dict, kCMSampleAttachmentKey_DisplayImmediately,
+                             kCFBooleanTrue);
+        if (!isSync && !avcc.contains_idr) {
+            CFDictionarySetValue(dict, kCMSampleAttachmentKey_NotSync,
+                                 kCFBooleanTrue);
+        }
+    }
+
+    if (layer.status == AVQueuedSampleBufferRenderingStatusFailed) {
+        [layer flush];
+    }
+    [layer enqueueSampleBuffer:sample];
+    CFRelease(sample);
+    [layer release];
+    return YES;
+}
+
+- (void)readerLoop
+{
+    [self logAt:0 message:"reader: start"];
+    while (_impl->running.load()) {
+        Bambu_Tunnel tunnel = nullptr;
+        {
+            std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+            tunnel = _impl->tunnel;
+        }
+        if (!tunnel) break;
+
+        Bambu_Sample sample{};
+        int rc = Bambu_ReadSample(tunnel, &sample);
+        if (rc == Bambu_would_block) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(15));
+            continue;
+        }
+        if (rc == Bambu_stream_end || rc < 0) {
+            char buf[128];
+            snprintf(buf, sizeof(buf), "reader: stream ended rc=%d", rc);
+            [self logAt:-1 message:buf];
+            [self emitTrack:"liveview_stream" phase:"read" result:"end" error:"eof"];
+            break;
+        }
+        if (rc != Bambu_success || !sample.buffer || sample.size <= 0) {
+            continue;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        {
+            std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+            if (!_impl->gotFirstPacket) {
+                _impl->gotFirstPacket = true;
+                _impl->firstPacketMs =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        now - _impl->openTime).count();
+            }
+            if (_impl->frameCount > 0) {
+                auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    now - _impl->lastFrameTime).count();
+                float gapf = static_cast<float>(gap);
+                if (gap > 500) {
+                    _impl->freezeCount += 1;
+                    _impl->freezeTotalMs += gap;
+                }
+                float jitter = gapf - 33.f;
+                if (jitter < 0) jitter = -jitter;
+                _impl->jitterSumMs += jitter;
+                if (jitter > _impl->maxJitterMs) _impl->maxJitterMs = jitter;
+            }
+            _impl->lastFrameTime = now;
+            _impl->byteCount += static_cast<uint64_t>(sample.size);
+        }
+
+        const bool isSync = (sample.flags & 1) != 0 ||
+            obn::h264::contains_idr(sample.buffer,
+                                    static_cast<size_t>(sample.size));
+
+        std::vector<uint8_t> copy(sample.buffer, sample.buffer + sample.size);
+
+        auto decode_start = std::chrono::steady_clock::now();
+        BOOL ok = [self enqueueAnnexB:copy.data()
+                                 size:copy.size()
+                                 sync:isSync ? YES : NO];
+        auto decode_end = std::chrono::steady_clock::now();
+        if (!ok) continue;
+
+        FirstFrameFn ffCb = nullptr;
+        void const*  ffCtx = nullptr;
+        BambuFirstFrameInfo ffInfo{};
+        bool fireFirst = false;
+        {
+            std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+            _impl->frameCount += 1;
+            if (!_impl->gotFirstFrame) {
+                _impl->gotFirstFrame = true;
+                _impl->firstDecodeMs =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        decode_end - decode_start).count();
+                ffInfo.first_packet_ms = _impl->firstPacketMs;
+                ffInfo.decode_ms       = _impl->firstDecodeMs;
+                ffInfo.render_ms =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        decode_end - _impl->openTime).count();
+                ffInfo.codec  = 0;
+                ffInfo.width  = _impl->videoW;
+                ffInfo.height = _impl->videoH;
+                ffCb  = _impl->firstFrameCb;
+                ffCtx = _impl->firstFrameCtx;
+                fireFirst = true;
+            }
+        }
+        if (fireFirst) {
+            if (ffCb) ffCb(ffCtx, &ffInfo);
+            [self emitTrack:"liveview_first_frame" phase:"play" result:"ok" error:nullptr];
+            [self logAt:0 message:"reader: first frame"];
+        }
+    }
+
+    [self logAt:0 message:"reader: exit"];
+    _impl->running.store(false);
+}
+
+@end

--- a/stubs/BambuPlayer.mm
+++ b/stubs/BambuPlayer.mm
@@ -469,6 +469,26 @@ static void bambu_logger_bridge(void* context, int level, char const* msg)
 
 - (int)play
 {
+    // Reap a previous reader that exited on its own (EOF/error) without
+    // close. Joining must happen *outside* the mutex — readerLoop may
+    // still be taking _impl->mu on its way out. Deleting a joinable
+    // std::thread is UB (std::terminate).
+    std::thread* stale = nullptr;
+    {
+        std::lock_guard<std::recursive_mutex> lk(_impl->mu);
+        if (!_impl->tunnel) {
+            [self logAt:1 message:"play: no open tunnel [-1]"];
+            return -1;
+        }
+        if (_impl->running.load()) return 0;
+        stale = _impl->reader;
+        _impl->reader = nullptr;
+    }
+    if (stale) {
+        if (stale->joinable()) stale->join();
+        delete stale;
+    }
+
     {
         std::lock_guard<std::recursive_mutex> lk(_impl->mu);
         if (!_impl->tunnel) {
@@ -479,10 +499,6 @@ static void bambu_logger_bridge(void* context, int level, char const* msg)
         _impl->running.store(true);
         _impl->sessionStart  = std::chrono::steady_clock::now();
         _impl->lastFrameTime = _impl->sessionStart;
-        if (_impl->reader) {
-            delete _impl->reader;
-            _impl->reader = nullptr;
-        }
         _impl->reader = new std::thread([self] { [self readerLoop]; });
     }
     [self emitTrack:"liveview_play" phase:"play" result:"ok" error:nullptr];
@@ -740,11 +756,12 @@ static void bambu_logger_bridge(void* context, int level, char const* msg)
             obn::h264::contains_idr(sample.buffer,
                                     static_cast<size_t>(sample.size));
 
-        std::vector<uint8_t> copy(sample.buffer, sample.buffer + sample.size);
-
+        // sample.buffer is borrowed until the next Bambu_ReadSample; we
+        // consume it synchronously here (and enqueueAnnexB copies into a
+        // CMBlockBuffer), so no intermediate std::vector is needed.
         auto decode_start = std::chrono::steady_clock::now();
-        BOOL ok = [self enqueueAnnexB:copy.data()
-                                 size:copy.size()
+        BOOL ok = [self enqueueAnnexB:sample.buffer
+                                 size:static_cast<size_t>(sample.size)
                                  sync:isSync ? YES : NO];
         auto decode_end = std::chrono::steady_clock::now();
         if (!ok) continue;

--- a/stubs/BambuSource.cpp
+++ b/stubs/BambuSource.cpp
@@ -279,28 +279,43 @@ bool parse_url(const std::string& url, TunnelUrl* out)
 {
     // Recognise the three URL shapes Studio hands us. Whichever it is,
     // strip the prefix and leave `rest` = "<...>[?query]".
-    static const std::string p_local  = "bambu:///local/";
-    static const std::string p_rtsps  = "bambu:///rtsps___";
-    static const std::string p_rtsp   = "bambu:///rtsp___";
+    //
+    // wxURI (macOS wxMediaCtrl2 / Windows DShow path) may collapse
+    // authority-less `bambu:///rtsps___…` into `bambu://rtsps___…`
+    // before Load/open. Accept any run of `/` after `bambu:` — same
+    // normaliser as stubs/dshow_filter.cpp.
+    static const char kBambu[] = "bambu:";
+    std::string body;
+    if (url.compare(0, sizeof(kBambu) - 1, kBambu) == 0) {
+        size_t p = sizeof(kBambu) - 1;
+        while (p < url.size() && url[p] == '/') ++p;
+        body = url.substr(p);
+    } else {
+        body = url;
+    }
+
+    static const std::string p_local = "local/";
+    static const std::string p_rtsps = "rtsps___";
+    static const std::string p_rtsp  = "rtsp___";
 
     std::string rest;
-    if (url.compare(0, p_local.size(), p_local) == 0) {
+    if (body.compare(0, p_local.size(), p_local) == 0) {
         out->scheme = Scheme::Local;
         out->port   = 6000;
-        rest = url.substr(p_local.size());
-    } else if (url.compare(0, p_rtsps.size(), p_rtsps) == 0) {
+        rest = body.substr(p_local.size());
+    } else if (body.compare(0, p_rtsps.size(), p_rtsps) == 0) {
         out->scheme = Scheme::Rtsps;
         out->port   = 322;
-        rest = url.substr(p_rtsps.size());
-    } else if (url.compare(0, p_rtsp.size(), p_rtsp) == 0) {
+        rest = body.substr(p_rtsps.size());
+    } else if (body.compare(0, p_rtsp.size(), p_rtsp) == 0) {
         out->scheme = Scheme::Rtsp;
         out->port   = 554;
-        rest = url.substr(p_rtsp.size());
+        rest = body.substr(p_rtsp.size());
     } else {
         // Bare "<ip>:<port>/..." fallback.
         out->scheme = Scheme::Local;
         out->port   = 6000;
-        rest = url;
+        rest = body;
     }
 
     // Split host.part vs ?query.

--- a/stubs/h264_avcc.cpp
+++ b/stubs/h264_avcc.cpp
@@ -1,0 +1,109 @@
+#include "h264_avcc.hpp"
+
+namespace obn {
+namespace h264 {
+namespace {
+
+// Find the next Annex-B start code at or after `off`.
+// Returns the index of the first 0x00 of the start code, or `size` if none.
+// On success, `*sc_len` is 3 or 4.
+size_t find_start_code(const uint8_t* data, size_t size, size_t off, size_t* sc_len)
+{
+    for (size_t i = off; i + 2 < size; ++i) {
+        if (data[i] == 0x00 && data[i + 1] == 0x00) {
+            if (data[i + 2] == 0x01) {
+                *sc_len = 3;
+                return i;
+            }
+            if (i + 3 < size && data[i + 2] == 0x00 && data[i + 3] == 0x01) {
+                *sc_len = 4;
+                return i;
+            }
+        }
+    }
+    return size;
+}
+
+struct NalView {
+    const uint8_t* data;
+    size_t         size;
+    uint8_t        type; // nal_unit_type (low 5 bits of first byte)
+};
+
+// Invoke `fn(NalView)` for every NAL in the Annex-B buffer.
+template <typename Fn>
+void for_each_nal(const uint8_t* data, size_t size, Fn fn)
+{
+    size_t sc_len = 0;
+    size_t sc     = find_start_code(data, size, 0, &sc_len);
+    while (sc < size) {
+        size_t nal_start = sc + sc_len;
+        size_t next_sc_len = 0;
+        size_t next = find_start_code(data, size, nal_start, &next_sc_len);
+        if (nal_start < next && nal_start < size) {
+            NalView v;
+            v.data = data + nal_start;
+            v.size = next - nal_start;
+            // Keep the NAL bytes verbatim (including any trailing_zero_8bits
+            // the encoder left before the next start code). Stripping 0x00
+            // would corrupt slice payloads that legitimately end in zero.
+            v.type = (v.size > 0) ? static_cast<uint8_t>(v.data[0] & 0x1f) : 0;
+            if (v.size > 0) fn(v);
+        }
+        if (next >= size) break;
+        sc     = next;
+        sc_len = next_sc_len;
+    }
+}
+
+void append_avcc_nal(std::vector<uint8_t>& out, const uint8_t* nal, size_t nal_size)
+{
+    const uint32_t n = static_cast<uint32_t>(nal_size);
+    out.push_back(static_cast<uint8_t>((n >> 24) & 0xff));
+    out.push_back(static_cast<uint8_t>((n >> 16) & 0xff));
+    out.push_back(static_cast<uint8_t>((n >>  8) & 0xff));
+    out.push_back(static_cast<uint8_t>( n        & 0xff));
+    out.insert(out.end(), nal, nal + nal_size);
+}
+
+} // namespace
+
+bool extract_parameter_sets(const uint8_t* data, size_t size, ParameterSets* out)
+{
+    if (!data || !out) return false;
+    out->sps.clear();
+    out->pps.clear();
+    for_each_nal(data, size, [&](const NalView& v) {
+        if (v.type == 7) out->sps.assign(v.data, v.data + v.size);
+        else if (v.type == 8) out->pps.assign(v.data, v.data + v.size);
+    });
+    return !out->sps.empty() && !out->pps.empty();
+}
+
+bool annexb_to_avcc(const uint8_t* data, size_t size, AvccFrame* out)
+{
+    if (!data || !out) return false;
+    out->data.clear();
+    out->contains_idr = false;
+    for_each_nal(data, size, [&](const NalView& v) {
+        // Parameter sets and AUDs belong in the format description / are
+        // not sample payload for AVSampleBufferDisplayLayer.
+        if (v.type == 7 || v.type == 8 || v.type == 9) return;
+        if (v.type == 5) out->contains_idr = true;
+        append_avcc_nal(out->data, v.data, v.size);
+    });
+    return !out->data.empty();
+}
+
+bool contains_idr(const uint8_t* data, size_t size)
+{
+    if (!data) return false;
+    bool found = false;
+    for_each_nal(data, size, [&](const NalView& v) {
+        if (v.type == 5) found = true;
+    });
+    return found;
+}
+
+} // namespace h264
+} // namespace obn

--- a/stubs/h264_avcc.cpp
+++ b/stubs/h264_avcc.cpp
@@ -1,5 +1,8 @@
 #include "h264_avcc.hpp"
 
+#include <cstdint>
+#include <limits>
+
 namespace obn {
 namespace h264 {
 namespace {
@@ -43,10 +46,13 @@ void for_each_nal(const uint8_t* data, size_t size, Fn fn)
         if (nal_start < next && nal_start < size) {
             NalView v;
             v.data = data + nal_start;
+            // Bytes between this start code and the next. The scanner
+            // consumes the next start-code prefix (00 00 01 / 00 00 00 01),
+            // so those zeros are not part of this NAL. Any
+            // trailing_zero_8bits that sit *before* that prefix remain in
+            // v.size. Do not strip trailing 0x00 — that would corrupt
+            // slice payloads that legitimately end in zero.
             v.size = next - nal_start;
-            // Keep the NAL bytes verbatim (including any trailing_zero_8bits
-            // the encoder left before the next start code). Stripping 0x00
-            // would corrupt slice payloads that legitimately end in zero.
             v.type = (v.size > 0) ? static_cast<uint8_t>(v.data[0] & 0x1f) : 0;
             if (v.size > 0) fn(v);
         }
@@ -56,14 +62,19 @@ void for_each_nal(const uint8_t* data, size_t size, Fn fn)
     }
 }
 
-void append_avcc_nal(std::vector<uint8_t>& out, const uint8_t* nal, size_t nal_size)
+// Append one length-prefixed NAL. AVCC lengths are 32-bit; reject anything
+// that would truncate. Returns false on overflow.
+bool append_avcc_nal(std::vector<uint8_t>& out, const uint8_t* nal, size_t nal_size)
 {
+    if (nal_size > static_cast<size_t>(std::numeric_limits<uint32_t>::max()))
+        return false;
     const uint32_t n = static_cast<uint32_t>(nal_size);
     out.push_back(static_cast<uint8_t>((n >> 24) & 0xff));
     out.push_back(static_cast<uint8_t>((n >> 16) & 0xff));
     out.push_back(static_cast<uint8_t>((n >>  8) & 0xff));
     out.push_back(static_cast<uint8_t>( n        & 0xff));
     out.insert(out.end(), nal, nal + nal_size);
+    return true;
 }
 
 } // namespace
@@ -85,13 +96,20 @@ bool annexb_to_avcc(const uint8_t* data, size_t size, AvccFrame* out)
     if (!data || !out) return false;
     out->data.clear();
     out->contains_idr = false;
+    bool ok = true;
     for_each_nal(data, size, [&](const NalView& v) {
+        if (!ok) return;
         // Parameter sets and AUDs belong in the format description / are
         // not sample payload for AVSampleBufferDisplayLayer.
         if (v.type == 7 || v.type == 8 || v.type == 9) return;
         if (v.type == 5) out->contains_idr = true;
-        append_avcc_nal(out->data, v.data, v.size);
+        if (!append_avcc_nal(out->data, v.data, v.size)) ok = false;
     });
+    if (!ok) {
+        out->data.clear();
+        out->contains_idr = false;
+        return false;
+    }
     return !out->data.empty();
 }
 

--- a/stubs/h264_avcc.hpp
+++ b/stubs/h264_avcc.hpp
@@ -1,0 +1,41 @@
+// Portable H.264 Annex-B helpers used by the macOS BambuPlayer adapter
+// (and unit-tested on Linux CI). No Apple / ObjC dependencies.
+//
+// Annex-B: NAL units prefixed with 00 00 01 or 00 00 00 01 start codes.
+// AVCC:   each NAL prefixed with a 4-byte big-endian length (no start codes).
+// AVSampleBufferDisplayLayer / CMVideoFormatDescription expect AVCC samples
+// plus out-of-band SPS/PPS parameter sets.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace obn {
+namespace h264 {
+
+struct ParameterSets {
+    std::vector<uint8_t> sps; // raw NAL (no start code), type 7
+    std::vector<uint8_t> pps; // raw NAL (no start code), type 8
+};
+
+struct AvccFrame {
+    std::vector<uint8_t> data; // one or more length-prefixed NALs
+    bool                 contains_idr = false;
+};
+
+// Walk Annex-B `data` and keep the last SPS (type 7) and PPS (type 8).
+// Returns true if both SPS and PPS were found.
+bool extract_parameter_sets(const uint8_t* data, size_t size, ParameterSets* out);
+
+// Convert an Annex-B access unit to AVCC. SPS / PPS / AUD NALs are dropped
+// from the payload (they belong in the format description). Returns false
+// if no convertible NAL remains.
+bool annexb_to_avcc(const uint8_t* data, size_t size, AvccFrame* out);
+
+// True if the Annex-B buffer contains an IDR slice (NAL type 5).
+bool contains_idr(const uint8_t* data, size_t size);
+
+} // namespace h264
+} // namespace obn

--- a/tests/h264_avcc_test.cpp
+++ b/tests/h264_avcc_test.cpp
@@ -1,0 +1,156 @@
+// Hermetic unit tests for stubs/h264_avcc.{hpp,cpp}.
+// Covers 3- and 4-byte Annex-B start codes, SPS/PPS extraction,
+// AVCC length framing, and IDR detection.
+
+#include "h264_avcc.hpp"
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using obn::h264::AvccFrame;
+using obn::h264::ParameterSets;
+using obn::h264::annexb_to_avcc;
+using obn::h264::contains_idr;
+using obn::h264::extract_parameter_sets;
+
+static int g_fail = 0;
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        std::printf("  FAIL: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        ++g_fail; \
+    } \
+} while (0)
+
+static void append_sc4(std::vector<uint8_t>& v)
+{
+    v.push_back(0); v.push_back(0); v.push_back(0); v.push_back(1);
+}
+
+static void append_sc3(std::vector<uint8_t>& v)
+{
+    v.push_back(0); v.push_back(0); v.push_back(1);
+}
+
+static void append_nal(std::vector<uint8_t>& v, uint8_t type,
+                       const uint8_t* payload, size_t n)
+{
+    append_sc4(v);
+    v.push_back(static_cast<uint8_t>(0x00 | (type & 0x1f))); // forbidden_zero=0, nal_ref_idc=0
+    if (payload && n > 0)
+        v.insert(v.end(), payload, payload + n);
+}
+
+static uint32_t be32(const uint8_t* p)
+{
+    return (uint32_t(p[0]) << 24) | (uint32_t(p[1]) << 16) |
+           (uint32_t(p[2]) <<  8) |  uint32_t(p[3]);
+}
+
+int main()
+{
+    // Fake SPS/PPS/slice payloads (content is opaque to the helper).
+    const uint8_t sps_body[] = { 0x42, 0x00, 0x1e, 0xaa };
+    const uint8_t pps_body[] = { 0xce, 0x01 };
+    const uint8_t idr_body[] = { 0x88, 0x84, 0x21 };
+    const uint8_t p_body[]   = { 0x9a, 0x10 };
+
+    // 1. extract_parameter_sets from a classic AU (4-byte start codes).
+    {
+        std::vector<uint8_t> au;
+        append_nal(au, 7, sps_body, sizeof(sps_body));
+        append_nal(au, 8, pps_body, sizeof(pps_body));
+        append_nal(au, 5, idr_body, sizeof(idr_body));
+
+        ParameterSets ps;
+        CHECK(extract_parameter_sets(au.data(), au.size(), &ps));
+        CHECK(ps.sps.size() == 1 + sizeof(sps_body));
+        CHECK(ps.pps.size() == 1 + sizeof(pps_body));
+        CHECK(ps.sps[0] == 7);
+        CHECK(ps.pps[0] == 8);
+        CHECK(std::memcmp(ps.sps.data() + 1, sps_body, sizeof(sps_body)) == 0);
+        CHECK(contains_idr(au.data(), au.size()));
+    }
+
+    // 2. 3-byte start codes also work.
+    {
+        std::vector<uint8_t> au;
+        append_sc3(au); au.push_back(7);
+        au.insert(au.end(), sps_body, sps_body + sizeof(sps_body));
+        append_sc3(au); au.push_back(8);
+        au.insert(au.end(), pps_body, pps_body + sizeof(pps_body));
+        append_sc3(au); au.push_back(1); // non-IDR slice
+        au.insert(au.end(), p_body, p_body + sizeof(p_body));
+
+        ParameterSets ps;
+        CHECK(extract_parameter_sets(au.data(), au.size(), &ps));
+        CHECK(ps.sps[0] == 7);
+        CHECK(ps.pps[0] == 8);
+        CHECK(!contains_idr(au.data(), au.size()));
+    }
+
+    // 3. annexb_to_avcc drops SPS/PPS/AUD and length-prefixes the rest.
+    {
+        std::vector<uint8_t> au;
+        append_nal(au, 7, sps_body, sizeof(sps_body));
+        append_nal(au, 8, pps_body, sizeof(pps_body));
+        append_nal(au, 9, nullptr, 0); // AUD (header only)
+        append_nal(au, 5, idr_body, sizeof(idr_body));
+
+        AvccFrame f;
+        CHECK(annexb_to_avcc(au.data(), au.size(), &f));
+        CHECK(f.contains_idr);
+        // One NAL: 4-byte length + 1 type byte + idr_body
+        const size_t nal_size = 1 + sizeof(idr_body);
+        CHECK(f.data.size() == 4 + nal_size);
+        CHECK(be32(f.data.data()) == nal_size);
+        CHECK(f.data[4] == 5);
+        CHECK(std::memcmp(f.data.data() + 5, idr_body, sizeof(idr_body)) == 0);
+    }
+
+    // 4. Non-IDR P-frame → contains_idr false, still convertible.
+    {
+        std::vector<uint8_t> au;
+        append_nal(au, 1, p_body, sizeof(p_body));
+        AvccFrame f;
+        CHECK(annexb_to_avcc(au.data(), au.size(), &f));
+        CHECK(!f.contains_idr);
+        CHECK(f.data.size() == 4 + 1 + sizeof(p_body));
+        CHECK(f.data[4] == 1);
+    }
+
+    // 5. Empty / SPS-only input → annexb_to_avcc fails (nothing left).
+    {
+        std::vector<uint8_t> au;
+        append_nal(au, 7, sps_body, sizeof(sps_body));
+        AvccFrame f;
+        CHECK(!annexb_to_avcc(au.data(), au.size(), &f));
+        CHECK(f.data.empty());
+    }
+
+    // 6. Mixed 3- and 4-byte start codes in one AU.
+    {
+        std::vector<uint8_t> au;
+        append_sc4(au); au.push_back(7);
+        au.insert(au.end(), sps_body, sps_body + sizeof(sps_body));
+        append_sc3(au); au.push_back(8);
+        au.insert(au.end(), pps_body, pps_body + sizeof(pps_body));
+        append_sc4(au); au.push_back(5);
+        au.insert(au.end(), idr_body, idr_body + sizeof(idr_body));
+
+        ParameterSets ps;
+        CHECK(extract_parameter_sets(au.data(), au.size(), &ps));
+        AvccFrame f;
+        CHECK(annexb_to_avcc(au.data(), au.size(), &f));
+        CHECK(f.contains_idr);
+    }
+
+    if (g_fail) {
+        std::printf("h264_avcc_test FAILED (%d)\n", g_fail);
+        return 1;
+    }
+    std::printf("h264_avcc_test OK\n");
+    return 0;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New threaded ObjC++/video display path on macOS with strict MRC and Studio ABI coupling, but it reuses the existing tunnel stack and is guarded by unit tests and CI symbol checks; end-to-end LiveView is not yet hardware-validated.
> 
> **Overview**
> Adds **macOS camera live view** by shipping an exported `BambuPlayer` Objective-C class in `libBambuSource.dylib`, which Orca/Bambu Studio’s `wxMediaCtrl2` loads via `dlsym`—fixing the indefinite “Loading…” state when only the `Bambu_*` C ABI was present.
> 
> The player reuses the existing RTSPS/H.264 **Annex-B** tunnel (`Bambu_Open` / `Bambu_ReadSample`), converts frames with a new portable **`h264_avcc`** helper, and renders through **`AVSampleBufferDisplayLayer`** (MRC, `-fno-objc-arc`, default visibility on the `@interface`). MJPEG `:6000` streams are rejected with `-3`. Optional Studio telemetry callbacks are implemented; passwords are redacted in bridged logs.
> 
> **Build/CI:** CMake enables ObjC++ on Apple, links AVFoundation/CoreMedia frameworks, and adds `h264_avcc_test`. macOS build/release workflows **`nm`-grep** for `_OBJC_CLASS_$_BambuPlayer`. **`parse_url`** in `BambuSource.cpp` now accepts wxURI’s collapsed `bambu://rtsps___…` URLs (aligned with the Windows DShow parser). Docs (`STATUS.md`, research §9.4) mark macOS `BambuPlayer` as implemented; hardware validation is still pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1894746a2a3cb2a80fae6261645bb955cb4f4e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->