### PR TITLE
Persist and reconnect the selected printer across restarts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,7 @@ add_library(bambu_networking SHARED
     src/os_compat.cpp
     src/oss_sign.cpp
     src/print_job.cpp
+    src/state.cpp
     src/print_job_naming.cpp
     src/signing.cpp
     src/ssdp.cpp
@@ -775,6 +776,17 @@ if(OBN_BUILD_TESTS AND NOT WIN32)
     target_include_directories(auth_persist_test PRIVATE include)
     add_test(NAME auth_persist COMMAND auth_persist_test)
 
+    # Hermetic regression test for issue #78: the selected printer must
+    # survive destruction and recreation of the networking Agent.
+    add_executable(state_persist_test tests/state_persist_test.cpp
+        tests/config_stub.cpp
+        src/state.cpp
+        src/json_lite.cpp
+        src/log.cpp
+        src/os_compat.cpp)
+    target_include_directories(state_persist_test PRIVATE include)
+    add_test(NAME state_persist COMMAND state_persist_test)
+
     add_executable(lan_live_test tests/lan_live_test.cpp
         src/agent.cpp
         src/auth.cpp
@@ -794,6 +806,7 @@ if(OBN_BUILD_TESTS AND NOT WIN32)
         src/mqtt_client.cpp
         src/print_params_ftp_prefs.cpp
         src/os_compat.cpp
+        src/state.cpp
         src/signing.cpp
         src/ssdp.cpp
         src/tls_dial.cpp
@@ -854,6 +867,7 @@ if(OBN_BUILD_TESTS AND NOT WIN32)
         src/print_job_naming.cpp
         src/print_params_ftp_prefs.cpp
         src/os_compat.cpp
+        src/state.cpp
         src/signing.cpp
         src/ssdp.cpp
         src/tls_dial.cpp

--- a/include/obn/agent.hpp
+++ b/include/obn/agent.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "obn/auth.hpp"
+#include "obn/state.hpp"
 #include "obn/bambu_networking.hpp"
 #include "obn/mqtt_client.hpp"
 
@@ -527,6 +528,10 @@ private:
     // Holds the cloud session (tokens + profile). Lazily populated from
     // <config_dir>/obn.auth.json as soon as config_dir_ is set.
     std::unique_ptr<obn::auth::Store> auth_store_;
+
+    // Holds small non-sensitive UI state. Orca expects the plugin to return
+    // the last selected printer after a process restart (#78).
+    std::unique_ptr<obn::state::Store> state_store_;
 
     // Tracks which printers we've already snapshotted a server cert for in
     // the current process. Keyed by dev_id. Studio's refresh timer calls

--- a/include/obn/state.hpp
+++ b/include/obn/state.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+// Small, non-sensitive plugin state that must survive slicer restarts.
+//
+// Bambu Studio / Orca ask the networking plugin for the last selected
+// printer during startup. Keep that value in <config_dir>/obn.state.json;
+// otherwise a newly-created Agent can only return an empty string and the
+// Device tab falls back to "No printer".
+
+#include <mutex>
+#include <string>
+
+namespace obn::state {
+
+class Store {
+public:
+    // Empty path disables disk persistence (useful for tests).
+    explicit Store(std::string path);
+
+    // Load the state file if it exists. Missing or malformed files leave the
+    // store at its safe default (no selected printer).
+    void load();
+
+    // Replace and persist the selected printer id. An empty id intentionally
+    // persists deselection so an older value cannot reappear after restart.
+    void set_selected_machine(std::string dev_id);
+
+    std::string selected_machine() const;
+
+private:
+    void persist_locked() const;
+
+    std::string        path_;
+    mutable std::mutex mu_;
+    std::string        selected_machine_;
+};
+
+} // namespace obn::state

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -1692,6 +1692,18 @@ void Agent::set_config_dir(std::string dir)
             obn::config::path_in_dir("obn.auth.json"));
         auth_store_->load();
         hydrate_session();
+
+        auto state = std::make_unique<obn::state::Store>(
+            obn::config::path_in_dir("obn.state.json"));
+        state->load();
+        const std::string selected = state->selected_machine();
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            user_selected_machine_ = selected;
+            state_store_ = std::move(state);
+        }
+        OBN_INFO("state: restored selected machine %s",
+                 selected.empty() ? "<none>" : selected.c_str());
     }
 }
 
@@ -1724,6 +1736,7 @@ void Agent::set_user_selected_machine(std::string dev_id)
         std::lock_guard<std::mutex> lk(mu_);
         user_selected_machine_ = std::move(dev_id);
         selected = user_selected_machine_;
+        if (state_store_) state_store_->set_selected_machine(selected);
     }
     // The user switched active printer: bring LAN up for the newly selected one
     // if its IP + access code are already known. connect_printer() inside

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -1704,6 +1704,12 @@ void Agent::set_config_dir(std::string dir)
         }
         OBN_INFO("state: restored selected machine %s",
                  selected.empty() ? "<none>" : selected.c_str());
+        // Discovery / cloud printer-info callbacks may already have populated
+        // the LAN IP and access-code caches before set_config_dir completes.
+        // Re-run the normal selection hook now so restoring the UI selection
+        // also reconnects telemetry. If either value is not ready yet this is
+        // a harmless no-op; the existing SSDP/access-code hooks retry later.
+        autostart_lan_if_selected(selected);
     }
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,0 +1,93 @@
+#include "obn/state.hpp"
+
+#include "obn/json_lite.hpp"
+#include "obn/log.hpp"
+
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <utility>
+
+namespace obn::state {
+
+Store::Store(std::string path) : path_(std::move(path)) {}
+
+void Store::load()
+{
+    std::lock_guard<std::mutex> lk(mu_);
+    selected_machine_.clear();
+    if (path_.empty()) return;
+
+    std::ifstream in(path_, std::ios::binary);
+    if (!in.good()) return;
+    std::string text((std::istreambuf_iterator<char>(in)),
+                     std::istreambuf_iterator<char>());
+    if (text.empty()) return;
+
+    std::string err;
+    auto root = obn::json::parse(text, &err);
+    if (!root) {
+        OBN_WARN("state: failed to parse %s: %s", path_.c_str(), err.c_str());
+        return;
+    }
+    selected_machine_ = root->find("selected_machine").as_string();
+}
+
+void Store::persist_locked() const
+{
+    if (path_.empty()) return;
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const fs::path parent = fs::path(path_).parent_path();
+    if (!parent.empty()) fs::create_directories(parent, ec);
+
+    const std::string tmp = path_ + ".tmp";
+    {
+        std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+        if (!out.good()) {
+            OBN_ERROR("state: open(%s) failed: %s", tmp.c_str(),
+                      std::strerror(errno));
+            return;
+        }
+        const std::string body =
+            "{\n  \"selected_machine\": " +
+            obn::json::escape(selected_machine_) + "\n}\n";
+        out.write(body.data(), static_cast<std::streamsize>(body.size()));
+        out.flush();
+        if (!out.good()) {
+            OBN_ERROR("state: partial write on %s", tmp.c_str());
+            out.close();
+            fs::remove(tmp, ec);
+            return;
+        }
+    }
+
+#if defined(_WIN32)
+    // std::filesystem::rename does not replace an existing Windows file.
+    fs::remove(path_, ec);
+#endif
+    fs::rename(tmp, path_, ec);
+    if (ec) {
+        OBN_ERROR("state: rename(%s -> %s) failed: %s",
+                  tmp.c_str(), path_.c_str(), ec.message().c_str());
+        std::error_code rmec;
+        fs::remove(tmp, rmec);
+    }
+}
+
+void Store::set_selected_machine(std::string dev_id)
+{
+    std::lock_guard<std::mutex> lk(mu_);
+    selected_machine_ = std::move(dev_id);
+    persist_locked();
+}
+
+std::string Store::selected_machine() const
+{
+    std::lock_guard<std::mutex> lk(mu_);
+    return selected_machine_;
+}
+
+} // namespace obn::state

--- a/tests/state_persist_test.cpp
+++ b/tests/state_persist_test.cpp
@@ -1,0 +1,104 @@
+#include "obn/state.hpp"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+#define EXPECT(r, cond)                                              \
+    do {                                                             \
+        if (cond) {                                                  \
+            (r).passed++;                                            \
+        } else {                                                     \
+            (r).failed++;                                            \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n",                \
+                         __FILE__, __LINE__, #cond);                  \
+        }                                                            \
+    } while (0)
+
+struct Result { int failed = 0; int passed = 0; };
+
+static fs::path tmp_path(const char* tag)
+{
+    return fs::temp_directory_path() /
+           (std::string("obn_state_test_") + tag + ".json");
+}
+
+void test_selection_survives_restart(Result& r)
+{
+    const fs::path path = tmp_path("restart");
+    fs::remove(path);
+    {
+        obn::state::Store store(path.string());
+        store.load();
+        EXPECT(r, store.selected_machine().empty());
+        store.set_selected_machine("31B8AP5C0101591");
+    }
+    {
+        obn::state::Store restarted(path.string());
+        restarted.load();
+        EXPECT(r, restarted.selected_machine() == "31B8AP5C0101591");
+    }
+    fs::remove(path);
+}
+
+void test_deselection_survives_restart(Result& r)
+{
+    const fs::path path = tmp_path("deselect");
+    fs::remove(path);
+    {
+        obn::state::Store store(path.string());
+        store.set_selected_machine("printer-a");
+        store.set_selected_machine("");
+    }
+    {
+        obn::state::Store restarted(path.string());
+        restarted.load();
+        EXPECT(r, restarted.selected_machine().empty());
+    }
+    fs::remove(path);
+}
+
+void test_malformed_state_is_safe(Result& r)
+{
+    const fs::path path = tmp_path("malformed");
+    {
+        std::ofstream out(path);
+        out << "not json";
+    }
+    obn::state::Store store(path.string());
+    store.load();
+    EXPECT(r, store.selected_machine().empty());
+    fs::remove(path);
+}
+
+void test_json_escaping_round_trip(Result& r)
+{
+    const fs::path path = tmp_path("escaping");
+    fs::remove(path);
+    const std::string unusual = "printer-\"test\\id";
+    {
+        obn::state::Store store(path.string());
+        store.set_selected_machine(unusual);
+    }
+    {
+        obn::state::Store restarted(path.string());
+        restarted.load();
+        EXPECT(r, restarted.selected_machine() == unusual);
+    }
+    fs::remove(path);
+}
+
+int main()
+{
+    Result r;
+    test_selection_survives_restart(r);
+    test_deselection_survives_restart(r);
+    test_malformed_state_is_safe(r);
+    test_json_escaping_round_trip(r);
+    std::printf("state_persist_test: %d passed, %d failed\n",
+                r.passed, r.failed);
+    return r.failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #78.

Persists the selected printer in `obn.state.json`, restores it when the networking agent starts, and reconnects the restored printer after discovery/configuration has populated its LAN connection details.

Without the startup reconnect, the printer selection was restored internally but OrcaSlicer still displayed “No printer” after restarting.

Testing:
- Added a regression test for persistence across agent recreation
- Focused tests passed: 5 passed, 0 failed
- Windows x64 `02.03.00` GitHub Actions build passed
- Tested with OrcaSlicer nightly and an H2C
- Printer, telemetry, controls, AMS information, and print status restored automatically across two consecutive restarts