### PR TITLE
Fix Windows RTSPS live-view routing

### DIFF
--- a/stubs/dshow_filter.cpp
+++ b/stubs/dshow_filter.cpp
@@ -284,6 +284,7 @@ struct ParsedUrl {
     std::string user = "bblp";
     std::string passwd;
     std::string path = "/streaming/live/1";
+    std::string lv;
 };
 
 std::string url_decode(const std::string& s)
@@ -402,9 +403,24 @@ bool parse_bambu_url(const std::string& url, ParsedUrl* out)
             else if (k == "port") {
                 try { out->port = std::stoi(v); } catch (...) {}
             }
+            else if (k == "lv") out->lv = v;
         }
         if (e == std::string::npos) break;
         i = e + 1;
+    }
+
+    // OBN's get_camera_url fallback intentionally uses one local URL for
+    // both the file-browser/control path and live video. H-series and
+    // other H.264 printers carry an lv=rtsps/rtsp hint on that URL.
+    // DirectShow is the Windows video path, so honor that hint here.
+    if (out->scheme == UrlScheme::Local) {
+        if (out->lv == "rtsps") {
+            out->scheme = UrlScheme::Rtsps;
+            out->port   = 322;
+        } else if (out->lv == "rtsp") {
+            out->scheme = UrlScheme::Rtsp;
+            out->port   = 554;
+        }
     }
 
     return !out->host.empty();


### PR DESCRIPTION
Fixes #77.

On Windows, the DirectShow filter can receive a `bambu://local/...` camera URL with an `lv=rtsps` or `lv=rtsp` hint. The URL parser currently keeps those URLs on the Local/MJPEG path, so H.264 live view is attempted on port 6000 instead of the RTSP(S) path.

This change:
- preserves the `lv` query parameter while parsing the camera URL;
- routes Local URLs with `lv=rtsps` to RTSPS on port 322;
- routes Local URLs with `lv=rtsp` to RTSP on port 554;
- leaves normal Local/MJPEG URLs unchanged.

Testing:
- Windows 11 x64
- OrcaSlicer + Bambu Lab H2C
- H2C live video displays correctly in Orca and continues working after fully closing and reopening Orca
- Release build completed successfully and produced `BambuSource.dll`
- `ctest --test-dir build -C Release --output-on-failure`: 1/1 tests passed

The H2C remained cloud-paired during hardware testing; printer controls, AMS/filament data, local printing, and Bambu Handy remote access continued to work normally.